### PR TITLE
Config boot ATR is now unloaded only when A8 sends MOUNT command

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -10,8 +10,8 @@
 #define FN_VERSION_MAJOR 0
 #define FN_VERSION_MINOR 1
 
-#define FN_VERSION_BUILD "5e189daf"
+#define FN_VERSION_BUILD "7f5a2cf7"
 
-#define FN_VERSION_DATE "2020-08-06 19:28:06"
+#define FN_VERSION_DATE "2020-08-07 04:58:59"
 
-#define FN_VERSION_FULL "0.1.5e189daf"
+#define FN_VERSION_FULL "0.1.7f5a2cf7"

--- a/lib/hardware/fnWiFi.cpp
+++ b/lib/hardware/fnWiFi.cpp
@@ -58,7 +58,7 @@ int WiFiManager::start()
     ESP_ERROR_CHECK(esp_wifi_start());
 
     // Set a hostname from our configuration
-    esp_err_t e = tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_STA, Config.get_general_devicename().c_str());
+    tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_STA, Config.get_general_devicename().c_str());
 
     _started = true;
     return 0;

--- a/lib/sio/apetime.cpp
+++ b/lib/sio/apetime.cpp
@@ -127,8 +127,11 @@ void sioApeTime::sio_status()
 {
 }
 
-void sioApeTime::sio_process()
+void sioApeTime::sio_process(uint32_t commanddata, uint8_t checksum)
 {
+    cmdFrame.commanddata = commanddata;
+    cmdFrame.checksum = checksum;
+    
     switch (cmdFrame.comnd)
     {
     case 0x93:

--- a/lib/sio/apetime.h
+++ b/lib/sio/apetime.h
@@ -6,8 +6,8 @@
 class sioApeTime : public sioDevice
 {
     public:
-    virtual void sio_process();
-    virtual void sio_status();
+    void sio_process(uint32_t commanddata, uint8_t checksum) override;
+    virtual void sio_status() override;
 
     private:
 

--- a/lib/sio/disk.cpp
+++ b/lib/sio/disk.cpp
@@ -246,8 +246,11 @@ bool sioDisk::write_blank(FILE *f, uint16_t sectorSize, uint16_t numSectors)
 }
 
 // Process command
-void sioDisk::sio_process()
+void sioDisk::sio_process(uint32_t commanddata, uint8_t checksum)
 {
+    cmdFrame.commanddata = commanddata;
+    cmdFrame.checksum = checksum;
+
     if (_disk == nullptr || _disk->_disktype == DISKTYPE_UNKNOWN)
         return;
 

--- a/lib/sio/disk.h
+++ b/lib/sio/disk.h
@@ -13,7 +13,7 @@ private:
     void sio_write(bool verify);
     void sio_format();
     void sio_status() override;
-    void sio_process() override;
+    void sio_process(uint32_t commanddata, uint8_t checksum) override;
 
     void derive_percom_block(uint16_t numSectors);
     void sio_read_percom_block();

--- a/lib/sio/fuji.h
+++ b/lib/sio/fuji.h
@@ -59,12 +59,12 @@ protected:
     void sio_set_hsio_index();         // 0xE3
 
     void sio_status() override;
-    void sio_process() override;
+    void sio_process(uint32_t commanddata, uint8_t checksum) override;
 
     void shutdown() override;
 
 public:
-    bool load_config = true;
+    bool boot_config = true;
     sioDisk *bootdisk();
     sioNetwork *network();
     void setup(sioBus *siobus);

--- a/lib/sio/modem.cpp
+++ b/lib/sio/modem.cpp
@@ -1365,8 +1365,11 @@ void sioModem::sio_handle_modem()
 /*
   Process command
 */
-void sioModem::sio_process()
+void sioModem::sio_process(uint32_t commanddata, uint8_t checksum)
 {
+    cmdFrame.commanddata = commanddata;
+    cmdFrame.checksum = checksum;
+
 #ifdef DEBUG
     Debug_println("sioModem::sio_process() called");
     static int i3F = 0;

--- a/lib/sio/modem.h
+++ b/lib/sio/modem.h
@@ -133,7 +133,7 @@ private:
     void sio_status() override;                  // $53, 'S', Status
     void sio_write();                            // $57, 'W', Write
     void sio_stream();                           // $58, 'X', Concurrent/Stream
-    void sio_process() override;                 // Process the command
+    void sio_process(uint32_t commanddata, uint8_t checksum) override;
     
     void crx_toggle(bool toggle);                // CRX active/inactive?
 

--- a/lib/sio/network.cpp
+++ b/lib/sio/network.cpp
@@ -979,8 +979,11 @@ void sioNetwork::sio_assert_interrupts()
     }
 }
 
-void sioNetwork::sio_process()
+void sioNetwork::sio_process(uint32_t commanddata, uint8_t checksum)
 {
+    cmdFrame.commanddata = commanddata;
+    cmdFrame.checksum = checksum;
+
     Debug_printf("sioNetwork::sio_process 0x%02hx '%c': 0x%02hx, 0x%02hx\n",
                  cmdFrame.comnd, cmdFrame.comnd, cmdFrame.aux1, cmdFrame.aux2);
 

--- a/lib/sio/network.h
+++ b/lib/sio/network.h
@@ -58,7 +58,6 @@ public:
     virtual void sio_close();
     virtual void sio_read();
     virtual void sio_write();
-    virtual void sio_status();
     virtual void sio_special();
 
     void sio_assert_interrupts();
@@ -81,7 +80,8 @@ public:
     bool sio_special_supported_40_command(unsigned char c);
     bool sio_special_supported_80_command(unsigned char c);
 
-    virtual void sio_process();
+    virtual void sio_status() override;
+    void sio_process(uint32_t commanddata, uint8_t checksum) override;
 
 private:
     string deviceSpec;

--- a/lib/sio/printer.cpp
+++ b/lib/sio/printer.cpp
@@ -234,8 +234,11 @@ sioPrinter::printer_type sioPrinter::match_modelname(std::string model_name)
 }
 
 // Process command
-void sioPrinter::sio_process()
+void sioPrinter::sio_process(uint32_t commanddata, uint8_t checksum)
 {
+    cmdFrame.commanddata = commanddata;
+    cmdFrame.checksum = checksum;
+
     switch (cmdFrame.comnd)
     {
     case SIO_PRINTERCMD_PUT: // Needed by A822 for graphics mode printing

--- a/lib/sio/printer.h
+++ b/lib/sio/printer.h
@@ -14,7 +14,7 @@ protected:
     uint8_t _buffer[40];
     void sio_write(uint8_t aux1, uint8_t aux2);
     void sio_status() override;
-    void sio_process() override;
+    void sio_process(uint32_t commanddata, uint8_t checksum) override;
     void shutdown() override;
 
     printer_emu *_pptr = nullptr;

--- a/lib/sio/sio.h
+++ b/lib/sio/sio.h
@@ -93,13 +93,17 @@ FN_HISPEED_INDEX=40 //  18,806 (18,806) baud
 union cmdFrame_t {
     struct
     {
-        unsigned char devic;
-        unsigned char comnd;
-        unsigned char aux1;
-        unsigned char aux2;
-        unsigned char cksum;
+        uint8_t device;
+        uint8_t comnd;
+        uint8_t aux1;
+        uint8_t aux2;
+        uint8_t cksum;
     };
-    uint8_t cmdFrameData[5];
+    struct
+    {
+        uint32_t commanddata;
+        uint8_t checksum;
+    } __attribute__((packed));
 };
 
 //helper functions
@@ -133,7 +137,7 @@ protected:
     unsigned short sio_get_aux();
 
     virtual void sio_status() = 0;
-    virtual void sio_process() = 0;
+    virtual void sio_process(uint32_t commanddata, uint8_t checksum) = 0;
 
     // Optional shutdown/reboot cleanup routine
     virtual void shutdown() {};

--- a/lib/sio/voice.cpp
+++ b/lib/sio/voice.cpp
@@ -53,8 +53,11 @@ void sioVoice::sio_status()
     sio_to_computer(status, sizeof(status), false);
 }
 
-void sioVoice::sio_process()
+void sioVoice::sio_process(uint32_t commanddata, uint8_t checksum)
 {
+    cmdFrame.commanddata = commanddata;
+    cmdFrame.checksum = checksum;
+
     // act like a printer for POC
     switch (cmdFrame.comnd)
     {

--- a/lib/sio/voice.h
+++ b/lib/sio/voice.h
@@ -15,8 +15,8 @@ protected:
     uint8_t buffer[41];
     void sio_write();
 
-    virtual void sio_process();
-    virtual void sio_status();
+    void sio_process(uint32_t commanddata, uint8_t checksum) override;
+    virtual void sio_status() override;
 
 private:
     void sio_sam();


### PR DESCRIPTION
Allows for rebooting Atari for testing and reload CONFIG as long as no MOUNT commands are executed.