### PR TITLE
Fix appkey struct alignment

### DIFF
--- a/lib/sio/fuji.h
+++ b/lib/sio/fuji.h
@@ -23,7 +23,7 @@
 #define READ_DEVICE_SLOTS_TAPE 0x10
 
 
-enum appkey_mode
+enum appkey_mode : uint8_t
 {
     APPKEYMODE_READ = 0,
     APPKEYMODE_WRITE,
@@ -36,6 +36,7 @@ struct appkey
     uint8_t app = 0;
     uint8_t key = 0;
     appkey_mode mode = APPKEYMODE_INVALID;
+    uint8_t reserved = 0;
 } __attribute__((packed));
 
 class sioFuji : public sioDevice


### PR DESCRIPTION
A simple way for the A8 to store a block of data (up to 64 bytes) on SD.  Need to set up a test program for this.