### PR TITLE
Double delay time in sioModem::sio_poll_1()

### DIFF
--- a/lib/sio/modem.cpp
+++ b/lib/sio/modem.cpp
@@ -229,7 +229,7 @@ void sioModem::sio_poll_1()
 
     Debug_println("Modem acknowledging Type 1 Poll");
 
-    fnSystem.delay_microseconds(DELAY_FIRMWARE_DELIVERY);
+    fnSystem.delay_microseconds(DELAY_FIRMWARE_DELIVERY*2);
 
     sio_to_computer(bootBlock, sizeof(bootBlock), false);
 }


### PR DESCRIPTION
In sioModem::sio_poll_1(), double the delay so there's plenty of time to load R: handler for stock machines and machines that support HSIO.