### PR TITLE
Add 8MB flash board

### DIFF
--- a/boards/fujinet-v1-8mb.json
+++ b/boards/fujinet-v1-8mb.json
@@ -1,0 +1,47 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_ESP32_DEV",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "esp32",
+    "partitions": "fujinet_partitions_8MB.csv"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "default_tool": "ftdi",
+    "onboard_tools": [
+      "ftdi"
+    ],
+    "openocd_board": "esp-wrover.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "#FujiNet v1 8MB",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "protocols": [
+      "esptool",
+      "espota",
+      "ftdi"
+    ],
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://github.com/FujiNetWIFI/atariwifi",
+  "vendor": "FujiNet Project"
+}

--- a/fujinet_partitions_8MB.csv
+++ b/fujinet_partitions_8MB.csv
@@ -1,0 +1,11 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+#
+#nvs        36,864 to    57,344   : size 20,480
+#otdata     57,344 to    65,536   : size 8,192
+#app0       65,536 to 6,291,456   : size 6,225,920
+#spiffs  6,291,456 to 8,388,608   : size 2,097,152
+#
+nvs,      data, nvs,     0x9000,  0x5000,      
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x5F0000,
+spiffs,   data, spiffs,  0x600000,0x200000,

--- a/platformio-sample - Copy.ini
+++ b/platformio-sample - Copy.ini
@@ -41,6 +41,20 @@ build_flags =
     ;-D VERBOSE_DISK
     ;-D VERBOSE_ATX
 
+; ESP32 WROVER (8MB Flash, 8MB PSRAM) based FujiNet
+[env:fujinet-v1-8mb]
+board = fujinet-v1-8mb
+build_type = debug
+build_flags =
+    ;-D JTAG
+    -D DEBUG_SPEED=921600
+    -D BLUETOOTH_SUPPORT
+    ;-D FN_HISPEED_INDEX=0
+    ;-D VERBOSE_SIO
+    ;-D VERBOSE_TNFS
+    ;-D VERBOSE_DISK
+    ;-D VERBOSE_ATX    
+
 ; ESP32 WROVER (4MB Flash, 8MB PSRAM) based FujiNet
 [env:fujinet-v1-4mb]
 board = fujinet-v1-4mb


### PR DESCRIPTION
Adding a build option and partition map for a WROVER module with 8MB flash (e.g. the official devkit C boards from Espressif) 