### PR TITLE
fix config write failure related crash

### DIFF
--- a/lib/config/fnConfig.cpp
+++ b/lib/config/fnConfig.cpp
@@ -576,7 +576,11 @@ void fnConfig::save()
     if (fnConfig::get_general_fnconfig_spifs() == true) //only if spiffs is enabled
     {
         Debug_println("SPIFFS Config Storage: Enabled. Saving config to SPIFFS");
-        fout = fnSPIFFS.file_open(CONFIG_FILENAME, "w");
+        if ( !(fout = fnSPIFFS.file_open(CONFIG_FILENAME, "w")))
+        {
+            Debug_println("Failed to Open config on SPIFFS");
+            return;
+        }
     }
     else
     {

--- a/lib/config/fnConfig.cpp
+++ b/lib/config/fnConfig.cpp
@@ -581,7 +581,11 @@ void fnConfig::save()
     else
     {
         Debug_println("SPIFFS Config Storage: Disabled. Saving config to SD");
-        fout = fnSDFAT.file_open(CONFIG_FILENAME, "w");
+        if ( !(fout = fnSDFAT.file_open(CONFIG_FILENAME, "w")))
+        {
+            Debug_println("Failed to Open config on SD");
+            return;
+        }
     }
         std::string result = ss.str();
         size_t z = fwrite(result.c_str(), 1, result.length(), fout);


### PR DESCRIPTION
This is workaround for bug causing SD is not being accessible when SIO2BT being enabled.
in case fnconfig_on_spiffs=0 that was causing crash.
