### PR TITLE
Add general/status_wait_enabled (default true).

### DIFF
--- a/data/www/index.html
+++ b/data/www/index.html
@@ -917,6 +917,24 @@
 							<script>
 								var current_config_enabled = "<%FN_CONFIG_ENABLED%>";
 							</script>
+							<br>Enable SIO STATUS wait routine 
+							<form action="/config" method="post">
+								<select name="status_wait_enable" id="select_status_wait_enable">
+									<optgroup>
+										<option value="1">Yes</option>
+										<option value="0">No</option>
+									</optgroup>
+								</select>
+								<input type="submit" value="Save">
+							</form>
+							<script>
+								var current_status_wait_enabled = "<%FN_STATUS_WAIT_ENABLED%>";
+							</script>
+							<span class="small">
+							Reboot FujiNet after changing this value.<br/>
+							Disabling the SIO STATUS wait will cause FujiNET will not wait other
+							devices answer OS status call. (like other DF1: floppy)<br/>
+							However it will fix issue with SpartaDOS X ejecting config Disk on boot.</span>
 							<hr>
 							<span class="small">
 							Reboot FujiNet after changing this value.<br/>

--- a/data/www/settings.js
+++ b/data/www/settings.js
@@ -27,3 +27,4 @@ selectListValue("select_config_enable", current_config_enabled);
 selectListValue("select_boot_mode", current_boot_mode);
 selectListValue("select_play_record", current_play_record);
 selectListValue("select_pulldown", current_pulldown);
+selectListValue("select_status_wait_enable", current_status_wait_enabled);

--- a/lib/config/fnConfig.cpp
+++ b/lib/config/fnConfig.cpp
@@ -484,6 +484,7 @@ void fnConfig::save()
     if (_general.timezone.empty() == false)
         ss << "timezone=" << _general.timezone << LINETERM;
     ss << "fnconfig_on_spifs=" << _general.fnconfig_spifs << LINETERM;
+    ss << "status_wait_enabled=" << _general.status_wait_enabled << LINETERM;
 
     ss << LINETERM;
 
@@ -835,6 +836,10 @@ void fnConfig::_read_section_general(std::stringstream &ss)
             else if (strcasecmp(name.c_str(), "fnconfig_on_spifs") == 0)
             {
                 _general.fnconfig_spifs = util_string_value_is_true(value);
+            }
+            else if (strcasecmp(name.c_str(), "status_wait_enabled") == 0)
+            {
+                _general.status_wait_enabled = util_string_value_is_true(value);
             }
         }
     }

--- a/lib/config/fnConfig.cpp
+++ b/lib/config/fnConfig.cpp
@@ -64,7 +64,14 @@ void fnConfig::store_general_config_enabled(bool config_enabled)
     _general.config_enabled = config_enabled;
     _dirty = true;
 }
+void fnConfig::store_general_status_wait_enabled(bool status_wait_enabled)
+{
+    if (_general.status_wait_enabled == status_wait_enabled)
+        return;
 
+    _general.status_wait_enabled = status_wait_enabled;
+    _dirty = true;
+}
 void fnConfig::store_general_boot_mode(uint8_t boot_mode)
 {
     if (_general.boot_mode == boot_mode)

--- a/lib/config/fnConfig.h
+++ b/lib/config/fnConfig.h
@@ -63,6 +63,8 @@ public:
     void store_midimaze_host(const char host_ip[64]);
     bool get_general_fnconfig_spifs() { return _general.fnconfig_spifs; };
     void store_general_fnconfig_spifs(bool fnconfig_spifs);
+    bool get_general_status_wait_enabled() { return _general.status_wait_enabled; }
+    void store_general_status_wait_enabled(bool status_wait_enabled);
 
     const char * get_network_sntpserver() { return _network.sntpserver; };
 
@@ -229,6 +231,7 @@ private:
         bool config_enabled = true;
         int boot_mode = 0;
         bool fnconfig_spifs = true;
+        bool status_wait_enabled = true;
     };
 
     struct modem_info

--- a/lib/http/httpServiceConfigurator.cpp
+++ b/lib/http/httpServiceConfigurator.cpp
@@ -177,6 +177,14 @@ void fnHttpServiceConfigurator::config_enable_config(std::string enable_config)
     Config.save();
 }
 
+void fnHttpServiceConfigurator::config_status_wait_enable(std::string status_wait_enable)
+{
+    Debug_printf("New status_wait_enable value: %s\n", status_wait_enable.c_str());
+    // Store our change in Config
+    Config.store_general_status_wait_enabled(util_string_value_is_true(status_wait_enable));
+    // Save change
+    Config.save();
+}
 void fnHttpServiceConfigurator::config_boot_mode(std::string boot_mode)
 {
     Debug_printf("New CONFIG Boot Mode value: %s\n", boot_mode.c_str());
@@ -339,6 +347,10 @@ int fnHttpServiceConfigurator::process_config_post(const char *postdata, size_t 
         else if (i->first.compare("config_enable") == 0)
         {
             config_enable_config(i->second);
+        }
+        else if (i->first.compare("status_wait_enable") == 0)
+        {
+            config_status_wait_enable(i->second);
         }
         else if (i->first.compare("boot_mode") == 0)
         {

--- a/lib/http/httpServiceConfigurator.h
+++ b/lib/http/httpServiceConfigurator.h
@@ -19,6 +19,7 @@ class fnHttpServiceConfigurator
     static void config_rotation_sounds(std::string rotation_sounds);
     static void config_enable_config(std::string enable_config);
     static void config_boot_mode(std::string boot_mode);
+    static void config_status_wait_enable(std::string status_wait_enable);
 
 public:
     static char * url_decode(char * dst, const char * src, size_t dstsize);

--- a/lib/http/httpServiceParser.cpp
+++ b/lib/http/httpServiceParser.cpp
@@ -56,6 +56,7 @@ const string fnHttpServiceParser::substitute_tag(const string &tag)
         FN_PLAY_RECORD,
         FN_PULLDOWN,
         FN_CONFIG_ENABLED,
+        FN_STATUS_WAIT_ENABLED,
         FN_BOOT_MODE,
         FN_DRIVE1HOST,
         FN_DRIVE2HOST,
@@ -134,6 +135,7 @@ const string fnHttpServiceParser::substitute_tag(const string &tag)
         "FN_PLAY_RECORD",
         "FN_PULLDOWN",
         "FN_CONFIG_ENABLED",
+        "FN_STATUS_WAIT_ENABLED",
         "FN_BOOT_MODE",
         "FN_DRIVE1HOST",
         "FN_DRIVE2HOST",
@@ -296,6 +298,9 @@ const string fnHttpServiceParser::substitute_tag(const string &tag)
         break;
     case FN_CONFIG_ENABLED:
         resultstream << Config.get_general_config_enabled();
+        break;
+    case FN_STATUS_WAIT_ENABLED:
+        resultstream << Config.get_general_status_wait_enabled();
         break;
     case FN_BOOT_MODE:
         resultstream << Config.get_general_boot_mode();

--- a/lib/sio/fuji.cpp
+++ b/lib/sio/fuji.cpp
@@ -1501,6 +1501,9 @@ void sioFuji::setup(sioBus *siobus)
 
     // Disable booting from CONFIG if our settings say to turn it off
     boot_config = Config.get_general_config_enabled();
+    
+    //Disable status_wait if our settings say to turn it off
+    status_wait_enabled = Config.get_general_status_wait_enabled();
 
     // Add our devices to the SIO bus
     for (int i = 0; i < MAX_DISK_DEVICES; i++)

--- a/lib/sio/fuji.h
+++ b/lib/sio/fuji.h
@@ -115,6 +115,9 @@ protected:
 
 public:
     bool boot_config = true;
+
+    bool status_wait_enabled = true;
+    
     sioDisk *bootdisk();
 
     sioNetwork *network();

--- a/lib/sio/sio.cpp
+++ b/lib/sio/sio.cpp
@@ -181,7 +181,7 @@ void sioBus::_sio_process_cmd()
         if (tempFrame.device == SIO_DEVICEID_DISK && _fujiDev != nullptr && _fujiDev->boot_config)
         {
             _activeDev = _fujiDev->bootdisk();
-            if (_activeDev->status_wait_count > 0 && tempFrame.comnd == 'R')
+            if (_activeDev->status_wait_count > 0 && tempFrame.comnd == 'R' && _fujiDev->status_wait_enabled)
             {
                 Debug_printf("Disabling CONFIG boot.\n");
                 _fujiDev->boot_config = false;


### PR DESCRIPTION
By default FujiNet when config disk is mounted on DF1 will wait for 5 status commands (status_wait_count) before replying to allow real devices to reply first.
However this make FujiNet incompatible with SpartaDOS X , that not sent status_wait but starts reading directly from DF1.
That was causing autorun.atr (config disk) being automagically ejected.

In this commit i implemented new flag in general section, that by default is set to 1 (to keep original functionality on)
if User set this flag to 0 , fujinet will not wait 5 status commands, which will allow to boot spartados and call config.com from there.

Second Commit implement proposed WebGui switch allowing alter general/status_wait_enabled flag.
Probably webgui message need to be slightly altered to make it more readable to nonexpirienced user.
but as functionality - it works :D