### PR TITLE
Restore ATDT5551234 functionality

### DIFF
--- a/lib/sio/modem.cpp
+++ b/lib/sio/modem.cpp
@@ -1060,6 +1060,9 @@ void sioModem::at_handle_dial()
         answered = false;
         answerTimer = fnSystem.millis();
         // This is so macros in Bobterm can do the actual connect.
+        fnSystem.delay(ANSWER_TIMER_MS);
+        at_cmd_println("CONNECT ", false);
+        at_cmd_println(modemBaud);
     }
     else
     {


### PR DESCRIPTION
This is accomplished by emitting a connect message when ATDT5551234 is sent.  We need to do a separate connect message here since we want to preserve command mode.  Otherwise, the follow-up ATDT command by the Bobterm macro would not work.