### PR TITLE
use of fnUartSIO.available() didn't take error result into account

### DIFF
--- a/lib/bus/adamnet/adamnet.cpp
+++ b/lib/bus/adamnet/adamnet.cpp
@@ -59,7 +59,7 @@ uint8_t adamNetDevice::adamnet_recv()
 {
     uint8_t b;
 
-    while (!fnUartSIO.available())
+    while (fnUartSIO.available() <= 0)
         fnSystem.yield();
 
     b = fnUartSIO.read();
@@ -163,12 +163,12 @@ void adamNetBus::wait_for_idle()
     do
     {
         // Wait for serial line to quiet down.
-        while (fnUartSIO.available())
+        while (fnUartSIO.available() > 0)
             fnUartSIO.read();
 
         start = current = esp_timer_get_time();
 
-        while ((!fnUartSIO.available()) && (isIdle == false))
+        while ((fnUartSIO.available() <= 0) && (isIdle == false))
         {
             current = esp_timer_get_time();
             dur = current - start;
@@ -218,7 +218,7 @@ void adamNetBus::_adamnet_process_queue()
 void adamNetBus::service()
 {
     // Process anything waiting.
-    if (fnUartSIO.available())
+    if (fnUartSIO.available() > 0)
         _adamnet_process_cmd();
 }
 

--- a/lib/bus/sio/sio.cpp
+++ b/lib/bus/sio/sio.cpp
@@ -80,7 +80,7 @@ uint8_t sioDevice::bus_to_peripheral(uint8_t *buf, unsigned short len)
     __END_IGNORE_UNUSEDVARS
 
     // Wait for checksum
-    while (0 == fnUartSIO.available())
+    while (fnUartSIO.available() <= 0)
         fnSystem.yield();
     uint8_t ck_rcv = fnUartSIO.read();
 

--- a/lib/device/adamnet/modem.cpp
+++ b/lib/device/adamnet/modem.cpp
@@ -1029,7 +1029,7 @@ void adamModem::sio_handle_modem()
 
         // In command mode - don't exchange with TCP but gather characters to a string
         //if (SIO_UART.available() /*|| blockWritePending == true */ )
-        if (fnUartSIO.available())
+        if (fnUartSIO.available() > 0)
         {
             // get char from Atari SIO
             //char chr = SIO_UART.read();
@@ -1123,7 +1123,7 @@ void adamModem::sio_handle_modem()
         }
 
         //int sioBytesAvail = SIO_UART.available();
-        int sioBytesAvail = fnUartSIO.available();
+        int sioBytesAvail = min(0, fnUartSIO.available());
 
         // send from Atari to Fujinet
         if (sioBytesAvail && tcpClient.connected())

--- a/lib/device/sio/midimaze.cpp
+++ b/lib/device/sio/midimaze.cpp
@@ -64,7 +64,7 @@ void sioMIDIMaze::sio_handle_midimaze()
     }
 
     // Read the data until there's a pause in the incoming stream
-    if (fnUartSIO.available())
+    if (fnUartSIO.available() > 0)
     {
         while (true)
         {
@@ -77,7 +77,7 @@ void sioMIDIMaze::sio_handle_midimaze()
                 sio_disable_midimaze();
                 return;
             }
-            if (fnUartSIO.available())
+            if (fnUartSIO.available() > 0)
             {
                 // Collect bytes read in our buffer
                 buf_midi[buf_midi_index] = (char)fnUartSIO.read();
@@ -87,7 +87,7 @@ void sioMIDIMaze::sio_handle_midimaze()
             else
             {
                 fnSystem.delay_microseconds(MIDIMAZE_PACKET_TIMEOUT);
-                if (!fnUartSIO.available())
+                if (fnUartSIO.available() <= 0)
                     break;
             }
         }

--- a/lib/device/sio/modem.cpp
+++ b/lib/device/sio/modem.cpp
@@ -1560,7 +1560,7 @@ void sioModem::sio_handle_modem()
 
         // In command mode - don't exchange with TCP but gather characters to a string
         //if (SIO_UART.available() /*|| blockWritePending == true */ )
-        if (fnUartSIO.available())
+        if (fnUartSIO.available() > 0)
         {
             // get char from Atari SIO
             //char chr = SIO_UART.read();
@@ -1654,7 +1654,7 @@ void sioModem::sio_handle_modem()
         }
 
         //int sioBytesAvail = SIO_UART.available();
-        int sioBytesAvail = fnUartSIO.available();
+        int sioBytesAvail = min(0, fnUartSIO.available());
 
         // send from Atari to Fujinet
         if (sioBytesAvail && tcpClient.connected())

--- a/lib/hardware/fnBluetooth.cpp
+++ b/lib/hardware/fnBluetooth.cpp
@@ -57,7 +57,7 @@ eBTBaudrate BluetoothManager::toggleBaudrate()
 
 void BluetoothManager::service()
 {
-    if (fnUartSIO.available())
+    if (fnUartSIO.available() > 0)
     {
         btSpp.write(fnUartSIO.read());
     }

--- a/lib/runcpm/abstraction_fujinet.h
+++ b/lib/runcpm/abstraction_fujinet.h
@@ -471,16 +471,16 @@ uint8_t _sys_makedisk(uint8_t drive)
 int _kbhit(void)
 {
 	if (teeMode == true)
-		return client.available() | fnUartSIO.available();
+		return client.available() | (fnUartSIO.available()>0);
 	else
-		return fnUartSIO.available();
+		return min(0, fnUartSIO.available());
 }
 
 uint8_t _getch(void)
 {
 	if (teeMode == true)
 	{
-		while (!fnUartSIO.available())
+		while (fnUartSIO.available() > 0)
 		{
 			if (client.available())
 			{
@@ -493,7 +493,7 @@ uint8_t _getch(void)
 	}
 	else
 	{
-		while (!fnUartSIO.available())
+		while (fnUartSIO.available() <= 0)
 		{
 		}
 		return fnUartSIO.read() & 0x7f;


### PR DESCRIPTION
use of fnUartSIO.available() returns -1 on error 
