### PR TITLE
Json stuff

### DIFF
--- a/lib/device/sio/network.cpp
+++ b/lib/device/sio/network.cpp
@@ -1091,7 +1091,7 @@ void sioNetwork::sio_set_json_query()
 
     inp = strrchr((const char *)in, ':');
     inp++;
-    json.setReadQuery(string(inp));
+    json.setReadQuery(string(inp), cmdFrame.aux2);
     json_bytes_remaining = json.readValueLen();
     tmp = (uint8_t *)malloc(json.readValueLen());
     json.readValue(tmp,json_bytes_remaining);

--- a/lib/fnjson/fnjson.cpp
+++ b/lib/fnjson/fnjson.cpp
@@ -54,9 +54,10 @@ void FNJSON::setProtocol(NetworkProtocol *newProtocol)
 /**
  * Set read query string
  */
-void FNJSON::setReadQuery(string queryString)
+void FNJSON::setReadQuery(string queryString, uint8_t queryParam)
 {
     _queryString = queryString;
+    _queryParam = queryParam;
     _item = resolveQuery();
     json_bytes_remaining=readValueLen();
 }

--- a/lib/fnjson/fnjson.cpp
+++ b/lib/fnjson/fnjson.cpp
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <math.h>
 #include <iomanip>
+#include <ostream>
 
 #include "../../include/debug.h"
 
@@ -103,8 +104,48 @@ string FNJSON::getValue(cJSON *item)
 
         Debug_printf("S: [cJSON_IsString] %s\n",cJSON_GetStringValue(item));
 
-        //ss << string(cJSON_GetStringValue(item));
         ss << cJSON_GetStringValue(item);
+        #ifdef BUILD_ATARI
+
+        // SIO AUX bits 0+1 control the mapping
+        //   Bit 0=0 - don't touch the characters
+        //   Bit 0=1 - convert the characters when possible
+        //   Bit 1=0 - convert to generic ASCII/ATASCII (no font change needed)
+        //   Bit 1=1 - convert to ATASCII international charset (need to be switched on ATARI, i.e via POKE 756,204)
+        
+        // SIO AUX2 Bit 1 set?
+        if ((_queryParam & 1) != 0)
+        {
+            // yes, map special characters
+            string str_utf8mapping = ss.str(); 
+            Debug_printf("S: [Mapping->ATARI]\n");
+
+            // SIO AUX2 Bit 2 set?
+            if ((_queryParam & 2) != 0)
+            {
+                // yes, mapping to international charset
+                string mapFrom[] =  { "á",    "ù",    "Ñ",    "É",    "ç",    "ô",    "ò",    "ì",    "£",    "ï",    "ü",    "ä",    "Ö",    "ú",    "ó",    "ö",    "Ü",    "â",    "û",    "î",    "é",    "è",    "ñ",    "ê",    "å",    "à",    "Å",    "¡",    "Ä",    "ß"  };
+                string mapTo[] =    { "\x00", "\x01", "\x02", "\x03", "\x04", "\x05", "\x06", "\x07", "\x08", "\x09", "\x0a", "\x0b", "\x0c", "\x0d", "\x0e", "\x0f", "\x10", "\x11", "\x12", "\x13", "\x14", "\x15", "\x16", "\x17", "\x18", "\x19", "\x1a", "\x60", "\x7b", "ss" };
+                int elementCount = sizeof(mapFrom)/sizeof(mapFrom[0]);
+                for (int elementIndex=0; elementIndex < elementCount; elementIndex++)
+                    if(str_utf8mapping.find(mapFrom[elementIndex]) != std::string::npos) 
+                        str_utf8mapping.replace(str_utf8mapping.find(mapFrom[elementIndex]), string(mapFrom[elementIndex]).size(), mapTo[elementIndex]);
+            }
+            else
+            {
+                // no, mapping to normal ASCI (workaround)
+                string mapFrom[] =  { "Ä",  "Ö",  "Ü",  "ä",  "ö",  "ü",  "ß",  "é", "è", "á", "à", "ó", "ò", "ú", "ù" };
+                string mapTo[] =    { "Ae", "Oe", "Ue", "ae", "oe", "ue", "ss", "e", "e", "a", "a", "o", "o", "u", "u" };
+                int elementCount = sizeof(mapFrom)/sizeof(mapFrom[0]);
+                for (int elementIndex=0; elementIndex < elementCount; elementIndex++)
+                    if(str_utf8mapping.find(mapFrom[elementIndex]) != std::string::npos) 
+                        str_utf8mapping.replace(str_utf8mapping.find(mapFrom[elementIndex]), string(mapFrom[elementIndex]).size(), mapTo[elementIndex]);
+            }
+
+            ss.str(str_utf8mapping);
+            Debug_printf("S: [Mapping->ATARI] %s\n",ss.str().c_str());
+        }
+        #endif
 
         return processString(ss.str() + lineEnding);
     }

--- a/lib/fnjson/fnjson.h
+++ b/lib/fnjson/fnjson.h
@@ -21,7 +21,7 @@ public:
 
     void setLineEnding(string _lineEnding);
     void setProtocol(NetworkProtocol *newProtocol);
-    void setReadQuery(string queryString);
+    void setReadQuery(string queryString, uint8_t queryParam);
     cJSON *resolveQuery();
     bool status(NetworkStatus *status);
     
@@ -36,6 +36,7 @@ private:
     cJSON *_item;
     NetworkProtocol *_protocol;
     string _queryString;
+    uint8_t _queryParam;
     string lineEnding;
     string getValue(cJSON *item);
     string _parseBuffer;


### PR DESCRIPTION
#514 
Now the JSON Query routine can convert UTF-8 special characters to ATARI compatible ones. You (the user) can control the conversion via SIO AUX2 when issuing the "Q" command. The lowest two bits decide what to do.
Bit 0=0 - no conversion at all
Bit 0=1 - conversion dependent on Bit 1
Bit 1=0 - conversion of the common latin diacritics (á, à, é etc.) by stripping the accent (á and à to a etc.) and German umlauts (ä, ö, ü, ß etc.) to the two letter transcription (ä to ae, ß to ss etc.)
Bit 1=1 - conversion of all characters contained in the ATASCII international character set (see [Wikipedia](https://en.wikipedia.org/wiki/ATASCII#International_Character_Set))

Example in BASIC: Call until now:
`XIO ASC("Q"),#1,12,0,"N:/path/to/string/element"` and an UTF-8 **ä** will be garbage

Change it to:
`XIO ASC("Q"),#1,12,1,"N:/path/to/string/element"` and the same **ä** will become an **ae**

Change it to:
`XIO ASC("Q"),#1,12,3,"N:/path/to/string/element"` and the same **ä** will become an ATASCII **ä** (don't forget to `POKE 756,204` to change the font)

_Note 1:_ An AUX2 value of 2 has no effect as in this case bit 0 is 0 so bit 1 is ignored.
_Note 2:_ The ATASCII font has no German **ß** so bit 2 makes no difference for the conversion, **ß** will always become **ss**
_Note 3:_ As in the past AUX2 was normally zero there should be no compatibility issues.
_Note 4:_ Due to my limited C++ knowledge the code regarding the multiple nested string arrays with different size should be refactored. It is working, but ugly and redundant.
