### PR TITLE
Real time clock support for the Apple II

### DIFF
--- a/lib/bus/iwm/iwm.cpp
+++ b/lib/bus/iwm/iwm.cpp
@@ -12,6 +12,7 @@
 #include "../device/iwm/disk.h"
 #include "../device/iwm/fuji.h"
 #include "../device/iwm/cpm.h"
+#include "../device/iwm/clock.h"
 
 /******************************************************************************
 Based on:
@@ -623,6 +624,9 @@ void iwmBus::addDevice(iwmDevice *pDevice, iwm_fujinet_type_t deviceType)
     case iwm_fujinet_type_t::Voice:
     // not yet implemented: todo - take SAM and implement as a special block device. Also then available for disk rotate annunciation. 
       break;
+    case iwm_fujinet_type_t::Clock:
+       _clockDev = (iwmClock *)pDevice;
+       break;
     case iwm_fujinet_type_t::Other:
       break;
     }

--- a/lib/bus/iwm/iwm.h
+++ b/lib/bus/iwm/iwm.h
@@ -56,10 +56,12 @@
 #define SP_TYPE_BYTE_FUJINET 0x10
 #define SP_TYPE_BYTE_FUJINET_NETWORK 0x11
 #define SP_TYPE_BYTE_FUJINET_CPM 0x12
+#define SP_TYPE_BYTE_FUJINET_CLOCK 0x13
 
 #define SP_SUBTYPE_BYTE_FUJINET 0x00
 #define SP_SUBTYPE_BYTE_FUJINET_NETWORK 0x00
 #define SP_SUBTYPE_BYTE_FUJINET_CPM 0x00
+#define SP_SUBTYPE_BYTE_FUJINET_CLOCK 0x00
 
 #define IWM_CTRL_RESET 0x00
 #define IWM_CTRL_SET_DCB 0x01
@@ -83,6 +85,7 @@ class iwmNetwork;  // declare here so can reference it, but define in network.h
 class iwmPrinter;  // Printer device
 class iwmDisk;     // disk device cause I need to use "iwmDisk smort" for prototyping in iwmBus::service()
 class iwmCPM;      // CPM Virtual Device
+class iwmClock;    // Real Time Clock Device
 class iwmBus;      // forward declare bus so can be friend
 
 // Sorry, this  is the protocol adapter's fault. -Thom
@@ -196,6 +199,7 @@ enum class iwm_fujinet_type_t
   CPM,
   Printer,
   Voice,
+  Clock,
   Other
 };
 
@@ -300,6 +304,7 @@ private:
   //sioCassette *_cassetteDev = nullptr;
   iwmCPM *_cpmDev = nullptr;
   iwmPrinter *_printerdev = nullptr;
+  iwmClock *_clockDev = nullptr;
 
   bool iwm_phase_val(uint8_t p);
 

--- a/lib/device/iwm/clock.cpp
+++ b/lib/device/iwm/clock.cpp
@@ -1,0 +1,126 @@
+#ifdef BUILD_APPLE
+#define CCP_INTERNAL
+
+#include "clock.h"
+
+#include "fnConfig.h"
+#include "../hardware/led.h"
+
+iwmClock::iwmClock()
+{
+}
+
+void iwmClock::send_status_reply_packet()
+{
+    uint8_t data[4];
+
+    // Build the contents of the packet
+    data[0] = STATCODE_DEVICE_ONLINE;
+    data[1] = 0; // block size 1
+    data[2] = 0; // block size 2
+    data[3] = 0; // block size 3
+    IWM.iwm_send_packet(id(),iwm_packet_type_t::status,SP_ERR_NOERROR, data, 4);
+}
+
+void iwmClock::send_status_dib_reply_packet()
+{
+    uint8_t data[25];
+
+    //* write data buffer first (25 bytes) 3 grp7 + 4 odds
+    // General Status byte
+    // Bit 7: Block  device
+    // Bit 6: Write allowed
+    // Bit 5: Read allowed
+    // Bit 4: Device online or disk in drive
+    // Bit 3: Format allowed
+    // Bit 2: Media write protected (block devices only)
+    // Bit 1: Currently interrupting (//c only)
+    // Bit 0: Currently open (char devices only)
+    data[0] = STATCODE_READ_ALLOWED | STATCODE_DEVICE_ONLINE;
+    data[1] = 0;    // block size 1
+    data[2] = 0;    // block size 2
+    data[3] = 0;    // block size 3
+    data[4] = 0x08; // ID string length - 11 chars
+    data[5] = 'F';
+    data[6] = 'N';
+    data[7] = '_';
+    data[8] = 'C';
+    data[9] = 'L';
+    data[10] = 'O';
+    data[11] = 'C';
+    data[12] = 'K';
+    data[13] = ' ';
+    data[14] = ' ';
+    data[15] = ' ';
+    data[16] = ' ';
+    data[17] = ' ';
+    data[18] = ' ';
+    data[19] = ' ';
+    data[20] = ' ';                           // ID string (16 chars total)
+    data[21] = SP_TYPE_BYTE_FUJINET_CLOCK;    // Device type    - 0x13  clock
+    data[22] = SP_SUBTYPE_BYTE_FUJINET_CLOCK; // Device Subtype - 0x00
+    data[23] = 0x00;                          // Firmware version 2 bytes
+    data[24] = 0x01;                          //
+    IWM.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR_NOERROR, data, 25);
+}
+
+void iwmClock::iwm_status(iwm_decoded_cmd_t cmd)
+{
+    uint8_t status_code = get_status_code(cmd); 
+    Debug_printf("\r\nDevice %02x Status Code %02x\n", id(), status_code);
+
+    switch (status_code)
+    {
+    case IWM_STATUS_STATUS: // 0x00
+        send_status_reply_packet();
+        return;
+        break;
+    case IWM_STATUS_DIB: // 0x03
+        send_status_dib_reply_packet();
+        return;
+        break;
+    case 'T': // Time
+        time_t tt = time(nullptr);
+        setenv("TZ",Config.get_general_timezone().c_str(),1);
+        tzset();
+        struct tm * now = localtime(&tt);
+
+        data_buffer[0] = (now->tm_year)/100 + 19;
+        data_buffer[1] = now->tm_year%100;
+        data_buffer[2] = now->tm_mon + 1;
+        data_buffer[3] = now->tm_mday;
+        data_buffer[4] = now->tm_hour;
+        data_buffer[5] = now->tm_min;
+        data_buffer[6] = now->tm_sec;
+        data_len = 7;
+        break;
+    }
+
+    Debug_printf("\r\nStatus code complete, sending response");
+    IWM.iwm_send_packet(id(), iwm_packet_type_t::data, 0, data_buffer, data_len);
+}
+
+
+void iwmClock::process(iwm_decoded_cmd_t cmd)
+{
+    fnLedManager.set(LED_BUS, true);
+    switch (cmd.command)
+    {
+    case 0x00: // status
+        Debug_printf("\r\nhandling status command");
+        iwm_status(cmd);
+        break;
+    default:
+        iwm_return_badcmd(cmd);
+        break;
+    } // switch (cmd)
+    fnLedManager.set(LED_BUS, false);
+}
+
+void iwmClock::shutdown()
+{
+}
+
+
+
+#endif /* BUILD_APPLE2 */

--- a/lib/device/iwm/clock.h
+++ b/lib/device/iwm/clock.h
@@ -1,0 +1,24 @@
+#ifndef IWMCLOCK_H
+#define IWMCLOCK_H
+
+#include "bus.h"
+
+class iwmClock : public iwmDevice
+{
+
+public:
+    iwmClock();
+
+    void process(iwm_decoded_cmd_t cmd) override;
+
+    void iwm_status(iwm_decoded_cmd_t cmd) override;
+
+    void shutdown() override;
+    void send_status_reply_packet() override;
+    void send_extended_status_reply_packet() override{};
+    void send_status_dib_reply_packet() override;
+    void send_extended_status_dib_reply_packet() override{};
+    
+};
+
+#endif /* IWMCLOCK_H */

--- a/lib/device/iwm/fuji.cpp
+++ b/lib/device/iwm/fuji.cpp
@@ -1028,6 +1028,9 @@ void iwmFuji::setup(iwmBus *iwmbus)
     theNetwork = new iwmNetwork();
     _iwm_bus->addDevice(theNetwork,iwm_fujinet_type_t::Network);
 
+    theClock = new iwmClock();
+    _iwm_bus->addDevice(theClock, iwm_fujinet_type_t::Clock);
+
     theCPM = new iwmCPM();
     _iwm_bus->addDevice(theCPM, iwm_fujinet_type_t::CPM);
 

--- a/lib/device/iwm/fuji.h
+++ b/lib/device/iwm/fuji.h
@@ -8,6 +8,7 @@
 #include "iwm/network.h"
 #include "iwm/printer.h"
 #include "iwm/cpm.h"
+#include "iwm/clock.h"
 
 #include "fujiHost.h"
 #include "fujiDisk.h"
@@ -83,6 +84,8 @@ private:
     iwmNetwork *theNetwork;
 
     iwmCPM *theCPM;
+
+    iwmClock *theClock;
 
     int _current_open_directory_slot = -1;
 


### PR DESCRIPTION
This PR adds RTC support for the Apple II. 

There is a new device on the Smartport bus. The new device responds to the common status code plus two more 'T' and 'P'.

'T' returns the current date and time on separate bytes, easy for any program to use.

'P' response is four packet bytes long with the format ProDOS uses internally and on the GetTime command. This is done to simplify the device driver.

Once this PR is complete, I will do a PR upstream for the ProDOS device driver, meanwhile the code for the driver is in https://github.com/ivanizag/prodos-drivers/tree/main/fujinet