### PR TITLE
build_webui.py: Use os.path.join in place of hardcoded slashes

### DIFF
--- a/build_webui.py
+++ b/build_webui.py
@@ -15,7 +15,8 @@ def prep_dst(fname, build_platform, prefix):
 
 def process_template(fname, build_platform, template_env, config, prefix):
     print(f"processing template file {fname}")
-    template = template_env.get_template(fname.replace(prefix, ''))
+    # jinja2 insists on '/' as the path separator even on windows. see https://github.com/pallets/jinja/issues/767
+    template = template_env.get_template(fname.replace(prefix, '').replace('\\', '/'))
     r = template.render(config)
     destination = prep_dst(fname, build_platform, prefix).replace('.tmpl.', '.')
     with open(destination, 'w') as f:

--- a/build_webui.py
+++ b/build_webui.py
@@ -6,7 +6,7 @@ from yaml import load, Loader
 
 def prep_dst(fname, build_platform, prefix):
     rel_path = fname.replace(prefix, '')
-    destination = f"data/{build_platform}/{rel_path}"
+    destination = os.path.join('data', build_platform, rel_path)
     dest_dir = os.path.dirname(destination)
     if not os.path.exists(dest_dir):
         os.makedirs(dest_dir)
@@ -35,7 +35,7 @@ if 'dev' in env["PROGRAM_ARGS"]:
     target = "dev"
 
 template_env = Environment(loader=FileSystemLoader("data/webui/template"))
-config = load(open(f"data/webui/config/{target}.yaml"), Loader=Loader)
+config = load(open(os.path.join('data', 'webui', 'config', f'{target}.yaml')), Loader=Loader)
 
 pio_config = configparser.ConfigParser()
 pio_config.read('platformio.ini')
@@ -45,18 +45,19 @@ print(f"Building webUI into data/{build_platform}")
 if not build_platform.startswith('BUILD_'):
     raise Exception(f"build_platform does not match BUILD_*, aborting")
 
-if (os.path.isdir(f"data/{build_platform}")):
-    shutil.rmtree(f"data/{build_platform}")
+data_build_platform_path = os.path.join("data", build_platform)
+if (os.path.isdir(data_build_platform_path)):
+    shutil.rmtree(data_build_platform_path)
 
 # copy common files not in www dir - these are files that do not need templating, e.g. binary files
-common_prefix = 'data/webui/common/'
+common_prefix = os.path.join('data', 'webui', 'common', '')
 for filename in glob.iglob(f'{common_prefix}**', recursive=True):
     if os.path.isfile(filename):
         copy_file(filename, build_platform, common_prefix)
 
 # copy template files, rendering if name matches *.tmpl.*
 template_matcher = re.compile(r'^.*\.tmpl\.[a-zA-Z0-9_]+$')
-webui_template_prefix = 'data/webui/template/'
+webui_template_prefix = os.path.join('data', 'webui', 'template', '')
 for filename in glob.iglob(f'{webui_template_prefix}**', recursive=True):
     if os.path.isfile(filename):
         if (template_matcher.search(filename)):
@@ -66,7 +67,8 @@ for filename in glob.iglob(f'{webui_template_prefix}**', recursive=True):
 
 # copy additional files from appropriate BUILD_* data dir, which is stored in the ini file under fujinet.build_platform
 # if there are file clashes, these will override the above, so it allows for device specific overrides
-dev_specific_prefix = f"data/webui/device_specific/{build_platform}"
-for filename in glob.iglob(f"{dev_specific_prefix}/**", recursive=True):
+
+dev_specific_prefix = os.path.join('data', 'webui', 'device_specific', build_platform, '')
+for filename in glob.iglob(f"{dev_specific_prefix}**", recursive=True):
     if os.path.isfile(filename) and filename != '.keep':
         copy_file(filename, build_platform, dev_specific_prefix)


### PR DESCRIPTION
Tested on windows and linux now.
jinja requires '/' in its paths, but when you're writing the data back out, you need backslashes on windows, so a combination of the two types of slashes are needed to get it working. hey ho.