### PR TITLE
Implement eject command, disk switched status reporting and write protected status reporting.

### DIFF
--- a/lib/bus/iwm/iwm.cpp
+++ b/lib/bus/iwm/iwm.cpp
@@ -579,6 +579,7 @@ void iwmBus::handle_init()
     pDevice = (*it);
     if (pDevice->id() == 0)
     {
+      pDevice->switched = false; //reset switched condition on init
       pDevice->_devnum = command_packet.dest; // assign address
       if (++it == _daisyChain.end())
         status = 0xff; // end of the line, so status=non zero - to do: check GPIO for another device in the physical daisy chain

--- a/lib/bus/iwm/iwm.h
+++ b/lib/bus/iwm/iwm.h
@@ -37,6 +37,7 @@
 #define STATCODE_WRITE_PROTECT 0x01 << 2  // block devices only
 #define STATCODE_INTERRUPTING 0x01 << 1   // apple IIc only
 #define STATCODE_DEVICE_OPEN 0x01 << 0    // char devices only
+#define STATCODE_DISK_SWITCHED 0x01 << 0 // disk switched status for block devices, same bit as device open for char devices
 
 // valid types and subtypes for block devices per smartport documentation
 #define SP_TYPE_BYTE_35DISK 0x01
@@ -260,6 +261,7 @@ protected:
   virtual void iwm_status(iwm_decoded_cmd_t cmd);
   virtual void iwm_readblock(iwm_decoded_cmd_t cmd) {};
   virtual void iwm_writeblock(iwm_decoded_cmd_t cmd) {};
+  virtual void iwm_handle_eject(iwm_decoded_cmd_t cmd) {};
   virtual void iwm_format(iwm_decoded_cmd_t cmd) {};
   virtual void iwm_ctrl(iwm_decoded_cmd_t cmd) {};
   virtual void iwm_open(iwm_decoded_cmd_t cmd) {};
@@ -277,6 +279,8 @@ protected:
 
 public:
   bool device_active;
+  bool switched = false; //indicate disk switched condition
+  bool readonly = true;  //write protected 
   bool is_config_device;
   /**
    * @brief get the IWM device Number (1-255)

--- a/lib/device/iwm/disk.cpp
+++ b/lib/device/iwm/disk.cpp
@@ -18,23 +18,23 @@ iwmDisk::~iwmDisk()
 uint8_t iwmDisk::smartport_device_type()
 {
   if (_disk == nullptr)
-    return 0x02;
+    return SP_TYPE_BYTE_HARDDISK;
 
   if (_disk->num_blocks < 1601)
-    return 0x01; // Floppy disk
+    return SP_TYPE_BYTE_35DISK; // Floppy disk
   else
-    return 0x02; // Hard disk
+    return SP_TYPE_BYTE_HARDDISK; // Hard disk
 }
 
 uint8_t iwmDisk::smartport_device_subtype()
 {
   if (_disk == nullptr)
-    return 0x0a;
+    return SP_SUBTYPE_BYTE_SWITCHED;
     
   if (_disk->num_blocks < 1601)
-    return 0x00; // Floppy disk
+    return SP_SUBTYPE_BYTE_SWITCHED; // Floppy disk
   else
-    return 0x0a; // Hard Disk
+    return SP_SUBTYPE_BYTE_SWITCHED; // Hard Disk
 }
 
 //*****************************************************************************
@@ -61,8 +61,16 @@ void iwmDisk::send_status_reply_packet()
   // Bit 3: Format allowed
   // Bit 2: Media write protected
   // Bit 1: Currently interrupting (//c only)
-  // Bit 0: Currently open (char devices only)
+  // Bit 0: Disk Switched 
   data[0] = 0b11101000;
+  if(switched) {
+    data[0] |= STATCODE_DISK_SWITCHED;
+    switched = false;
+    }
+  if(!device_active) {data[0] &= ~(STATCODE_DEVICE_ONLINE);}
+  if(device_active) {data[0] |= STATCODE_DEVICE_ONLINE;}
+  if(readonly) {data[0] |= STATCODE_WRITE_PROTECT;}
+  Debug_printf("send_status_reply packet() status = %02X\r\n",data[0]);
   data[1] = data[2] = data[3] = 0;
   if (_disk != nullptr)
   {
@@ -90,6 +98,14 @@ void iwmDisk::send_extended_status_reply_packet()
 {
   uint8_t data[5];
   data[0] = 0b11101000;
+  if(!device_active) {Debug_printf("Device not active!\r\n"); data[0] &= ~(STATCODE_DEVICE_ONLINE);}
+  if(device_active) {data[0] |= STATCODE_DEVICE_ONLINE;}
+  if(switched) {
+    data[0] |= STATCODE_DISK_SWITCHED;
+    switched = false;
+    }
+  if(readonly) {data[0] |= STATCODE_WRITE_PROTECT;}
+  Debug_printf("send_extended_status_reply_packet() status = %02X\r\n",data[0]);
   // Build the contents of the packet
   // Info byte
   // Bit 7: Block  device
@@ -138,8 +154,16 @@ void iwmDisk::send_status_dib_reply_packet() // to do - abstract this out with p
   // Bit 3: Format allowed
   // Bit 2: Media write protected (block devices only)
   // Bit 1: Currently interrupting (//c only)
-  // Bit 0: Currently open (char devices only)
+  // Bit 0: Disk switched
   data[0] = 0b11101000;
+  if(switched) {
+    data[0] |= STATCODE_DISK_SWITCHED;
+    switched = false;
+    }
+  if(!device_active) {Debug_printf("Device not active!\r\n"); data[0] &= ~(STATCODE_DEVICE_ONLINE);}
+  if(device_active) {data[0] |= STATCODE_DEVICE_ONLINE;}
+  if(readonly) {data[0] |= STATCODE_WRITE_PROTECT;}
+  Debug_printf("send_status_dib_reply_packet() status = %02X\r\n",data[0]);
   data[1] = 0;
   data[2] = 0;
   data[3] = 0;
@@ -203,8 +227,16 @@ void iwmDisk::send_extended_status_dib_reply_packet()
   // Bit 3: Format allowed
   // Bit 2: Media write protected (block devices only)
   // Bit 1: Currently interrupting (//c only)
-  // Bit 0: Currently open (char devices only)
+  // Bit 0: Disk Switched
   data[0] = 0b11101000;
+  if(switched) {
+    data[0] |= STATCODE_DISK_SWITCHED;
+    switched = false;
+    }
+  if(!device_active) {Debug_printf("Device not active!\r\n"); data[0] &= ~(STATCODE_DEVICE_ONLINE);}
+  if(device_active) {data[0] |= STATCODE_DEVICE_ONLINE;}
+  if(readonly) {data[0] |= STATCODE_WRITE_PROTECT;}
+  Debug_printf("send_extended_status_dib_reply_packet() status = %02X\r\n",data[0]);
   data[1] = 0;
   data[2] = 0;
   data[3] = 0;
@@ -243,7 +275,13 @@ void iwmDisk::send_extended_status_dib_reply_packet()
   data[24] = 0x0f; //
   IWM.iwm_send_packet(id(), iwm_packet_type_t::ext_status, SP_ERR_NOERROR, data, 25);
 }
-
+void iwmDisk::iwm_handle_eject(iwm_decoded_cmd_t cmd) {
+  Debug_printf("Hanlding Eject command\r\n");
+  unmount();
+  //switched = false; //force switched = false when ejected from host. 
+  iwm_return_noerror();
+  return;
+}
 void iwmDisk::process(iwm_decoded_cmd_t cmd)
 {
   uint8_t status_code;
@@ -274,7 +312,7 @@ void iwmDisk::process(iwm_decoded_cmd_t cmd)
     if (disk_num == '0' && status_code > 0x0A) // max regular control code is 0x0A to 3.5" disk
       theFuji.FujiControl(cmd);
     else  
-      iwm_return_badcmd(cmd);
+      iwm_handle_eject(cmd);
     break;
   case 0x06: // open
     iwm_return_badcmd(cmd);
@@ -303,14 +341,25 @@ void iwmDisk::iwm_readblock(iwm_decoded_cmd_t cmd)
 
   // source = cmd.dest; // we are the destination and will become the source // packet_buffer[6];
   Debug_printf("\r\nDrive %02x ", id());
-
+  if(switched){
+    /*Debug_printf("iwm_readblock() returning disk switched error\r\n");
+    send_reply_packet(SP_ERR_DISKSW);
+    switched = false;
+    return; */
+  }
   if (!(_disk != nullptr))
   {
     Debug_printf(" - ERROR - No image mounted");
     send_reply_packet(SP_ERR_OFFLINE);
     return;
   }
+  if(!device_active) {
+    Debug_printf("iwm_readblock while device offline!\r\n");
+    send_reply_packet(SP_ERR_OFFLINE);
+    return;
+  }
 
+  
   // LBH = cmd.grp7msb; //packet_buffer[16]; // high order bits
   // LBT = cmd.g7byte5; //packet_buffer[21]; // block number high
   // LBL = cmd.g7byte4; //packet_buffer[20]; // block number middle
@@ -341,6 +390,21 @@ void iwmDisk::iwm_readblock(iwm_decoded_cmd_t cmd)
 void iwmDisk::iwm_writeblock(iwm_decoded_cmd_t cmd)
 {
   uint8_t status = 0;
+  if(switched) {
+    /*send_reply_packet(SP_ERR_DISKSW);
+    switched = false;
+    return;*/
+  }
+ if(!device_active) {
+    Debug_printf("iwm_writeblock while device offline!\r\n");
+    send_reply_packet(SP_ERR_OFFLINE);
+    return;
+  }
+ if(readonly) {
+  Debug_printf("\r\niwm_writeblock tried to write while readonly = true!");
+  send_reply_packet(SP_ERR_NOWRITE);
+  return;
+ }
  //  uint8_t source = cmd.dest; // packet_buffer[6];
   // to do - actually we will already know that the cmd.dest == id(), so can just use id() here
   Debug_printf("\r\nDrive %02x ", id());
@@ -405,9 +469,8 @@ mediatype_t iwmDisk::mount(FILE *f, const char *filename, uint32_t disksize, med
 {
 
   mediatype_t mt = MEDIATYPE_UNKNOWN;
-
   Debug_printf("disk MOUNT %s\n", filename);
-
+   
   // Destroy any existing MediaType
   if (_disk != nullptr)
   {
@@ -424,6 +487,7 @@ mediatype_t iwmDisk::mount(FILE *f, const char *filename, uint32_t disksize, med
     case MEDIATYPE_PO:
         Debug_printf("\r\nMedia Type PO");
         device_active = true;
+        switched = true;
         _disk = new MediaTypePO();
         mt = _disk->mount(f, disksize);
         //_disk->fileptr() = f;
@@ -442,7 +506,16 @@ mediatype_t iwmDisk::mount(FILE *f, const char *filename, uint32_t disksize, med
 void iwmDisk::unmount()
   
 {
-  
+      if (_disk != nullptr)
+    {
+        _disk->unmount();
+        delete _disk;
+        _disk = nullptr;
+        device_active = false;
+        switched = true;
+        readonly = true;
+        Debug_printf("Disk UNMOUNTED!!!!\r\n");
+    }
 }
 
 bool iwmDisk::write_blank(FILE *f, uint16_t sectorSize, uint16_t numSectors)

--- a/lib/device/iwm/disk.cpp
+++ b/lib/device/iwm/disk.cpp
@@ -70,7 +70,7 @@ void iwmDisk::send_status_reply_packet()
   if(!device_active) {data[0] &= ~(STATCODE_DEVICE_ONLINE);}
   if(device_active) {data[0] |= STATCODE_DEVICE_ONLINE;}
   if(readonly) {data[0] |= STATCODE_WRITE_PROTECT;}
-  Debug_printf("send_status_reply packet() status = %02X\r\n",data[0]);
+  Debug_printf("\r\nstatus = %02X\r\n",data[0]);
   data[1] = data[2] = data[3] = 0;
   if (_disk != nullptr)
   {
@@ -98,14 +98,14 @@ void iwmDisk::send_extended_status_reply_packet()
 {
   uint8_t data[5];
   data[0] = 0b11101000;
-  if(!device_active) {Debug_printf("Device not active!\r\n"); data[0] &= ~(STATCODE_DEVICE_ONLINE);}
+  if(!device_active) {data[0] &= ~(STATCODE_DEVICE_ONLINE);}
   if(device_active) {data[0] |= STATCODE_DEVICE_ONLINE;}
   if(switched) {
     data[0] |= STATCODE_DISK_SWITCHED;
     switched = false;
     }
   if(readonly) {data[0] |= STATCODE_WRITE_PROTECT;}
-  Debug_printf("send_extended_status_reply_packet() status = %02X\r\n",data[0]);
+  Debug_printf("\r\n status = %02X\r\n",data[0]);
   // Build the contents of the packet
   // Info byte
   // Bit 7: Block  device
@@ -160,10 +160,10 @@ void iwmDisk::send_status_dib_reply_packet() // to do - abstract this out with p
     data[0] |= STATCODE_DISK_SWITCHED;
     switched = false;
     }
-  if(!device_active) {Debug_printf("Device not active!\r\n"); data[0] &= ~(STATCODE_DEVICE_ONLINE);}
+  if(!device_active) {data[0] &= ~(STATCODE_DEVICE_ONLINE);}
   if(device_active) {data[0] |= STATCODE_DEVICE_ONLINE;}
   if(readonly) {data[0] |= STATCODE_WRITE_PROTECT;}
-  Debug_printf("send_status_dib_reply_packet() status = %02X\r\n",data[0]);
+  Debug_printf("\r\nstatus = %02X\r\n",data[0]);
   data[1] = 0;
   data[2] = 0;
   data[3] = 0;
@@ -233,10 +233,10 @@ void iwmDisk::send_extended_status_dib_reply_packet()
     data[0] |= STATCODE_DISK_SWITCHED;
     switched = false;
     }
-  if(!device_active) {Debug_printf("Device not active!\r\n"); data[0] &= ~(STATCODE_DEVICE_ONLINE);}
+  if(!device_active) {data[0] &= ~(STATCODE_DEVICE_ONLINE);}
   if(device_active) {data[0] |= STATCODE_DEVICE_ONLINE;}
   if(readonly) {data[0] |= STATCODE_WRITE_PROTECT;}
-  Debug_printf("send_extended_status_dib_reply_packet() status = %02X\r\n",data[0]);
+  Debug_printf("\r\nstatus = %02X\r\n",data[0]);
   data[1] = 0;
   data[2] = 0;
   data[3] = 0;
@@ -342,10 +342,10 @@ void iwmDisk::iwm_readblock(iwm_decoded_cmd_t cmd)
   // source = cmd.dest; // we are the destination and will become the source // packet_buffer[6];
   Debug_printf("\r\nDrive %02x ", id());
   if(switched){
-    /*Debug_printf("iwm_readblock() returning disk switched error\r\n");
-    send_reply_packet(SP_ERR_DISKSW);
+    Debug_printf("iwm_readblock() returning disk switched error\r\n");
+    send_reply_packet(SP_ERR_OFFLINE);
     switched = false;
-    return; */
+    return;
   }
   if (!(_disk != nullptr))
   {
@@ -391,9 +391,9 @@ void iwmDisk::iwm_writeblock(iwm_decoded_cmd_t cmd)
 {
   uint8_t status = 0;
   if(switched) {
-    /*send_reply_packet(SP_ERR_DISKSW);
+    send_reply_packet(SP_ERR_OFFLINE);
     switched = false;
-    return;*/
+    return;
   }
  if(!device_active) {
     Debug_printf("iwm_writeblock while device offline!\r\n");

--- a/lib/device/iwm/disk.h
+++ b/lib/device/iwm/disk.h
@@ -35,7 +35,7 @@ protected:
     // void iwm_format();
     //void iwm_status(cmdPacket_t cmd); // override;
     void process(iwm_decoded_cmd_t cmd) override; // uint32_t commanddata, uint8_t checksum); // override;
-
+    void iwm_handle_eject(iwm_decoded_cmd_t cmd) override;
     void iwm_readblock(iwm_decoded_cmd_t cmd) override;
     void iwm_writeblock(iwm_decoded_cmd_t cmd) override;
     uint32_t get_block_number(iwm_decoded_cmd_t cmd) {return cmd.params[2] + (cmd.params[3] << 8) + (cmd.params[4] << 16); };

--- a/lib/device/iwm/fuji.cpp
+++ b/lib/device/iwm/fuji.cpp
@@ -211,6 +211,7 @@ void iwmFuji::iwm_ctrl_disk_image_mount() // SP CTRL command
 
     // And now mount it
     disk.disk_type = disk.disk_dev.mount(disk.fileh, disk.filename, disk.disk_size);
+    if(options == DISK_ACCESS_MODE_WRITE) {disk.disk_dev.readonly = false;}
 }
 
 
@@ -314,6 +315,7 @@ bool iwmFuji::mount_all()
 
             // And now mount it
             disk.disk_type = disk.disk_dev.mount(disk.fileh, disk.filename, disk.disk_size);
+            if(disk.access_mode == DISK_ACCESS_MODE_WRITE) {disk.disk_dev.readonly = false;}
         }
     }
 

--- a/lib/http/httpService.cpp
+++ b/lib/http/httpService.cpp
@@ -670,6 +670,9 @@ esp_err_t fnHttpService::get_handler_mount(httpd_req_t *req)
                 strcpy(disk->filename,qp.query_parsed["filename"].c_str());
                 disk->disk_size = host->file_size(disk->fileh);
                 disk->disk_type = disk->disk_dev.mount(disk->fileh, disk->filename, disk->disk_size);
+                #ifdef BUILD_APPLE
+                if(mode == fnConfig::mount_modes::MOUNTMODE_WRITE) {disk->disk_dev.readonly = false;}
+                #endif 
                 Config.store_mount(ds, hs, qp.query_parsed["filename"].c_str(), mode);
                 Config.save();
                 theFuji._populate_slots_from_config(); // otherwise they don't show up in config.


### PR DESCRIPTION
This is an experimental implementation of support for the eject command, 
disk switched status and treating read only mounted disks as proper write protected disks.  

You should be able to swap out disks during the System 6.0.1 install process with this installed.
