### PR TITLE
Eject improvements

### DIFF
--- a/lib/bus/iwm/iwm.cpp
+++ b/lib/bus/iwm/iwm.cpp
@@ -545,8 +545,7 @@ void IRAM_ATTR iwmBus::service()
       for (auto devicep : _daisyChain)
       {
 
-        if (command_packet.dest == devicep->_devnum &&
-            devicep->device_active == true)
+        if (command_packet.dest == devicep->_devnum)
 
         {
           // iwm_ack_assert(); // includes waiting for spi read transaction to finish
@@ -637,9 +636,6 @@ void iwmBus::handle_init()
     }
     // assign dev numbers
     pDevice = (*it);
-
-    if (pDevice->device_active == false)
-      continue;
     
     if (pDevice->id() == 0)
     {

--- a/lib/device/iwm/disk.cpp
+++ b/lib/device/iwm/disk.cpp
@@ -474,6 +474,8 @@ mediatype_t iwmDisk::mount(FILE *f, const char *filename, uint32_t disksize, med
   // Destroy any existing MediaType
   if (_disk != nullptr)
   {
+    device_active = false;
+    _disk->unmount();
     delete _disk;
     _disk = nullptr;
   }
@@ -490,6 +492,8 @@ mediatype_t iwmDisk::mount(FILE *f, const char *filename, uint32_t disksize, med
         switched = true;
         _disk = new MediaTypePO();
         mt = _disk->mount(f, disksize);
+        device_active = true; //change status only after we are mounted
+        switched = true;
         //_disk->fileptr() = f;
         // mt = MEDIATYPE_PO;
         break;


### PR DESCRIPTION
Change iwm so that inactive devices can still report back status/reply to init requests, this is important for removable media because
eject is removing the disk from the drive, not yanking the drive from the bus. 

this also fixes a problem where I was leaking memory when mounting a new disk on top of an already active slot
because I wasn't fully calling _disk->unmount() before destroying the _disk object and continuing with the mount process.