### PR TITLE
[iwm] Simulate an empty drive for one status cycle when mounting over…

### DIFF
--- a/lib/bus/iwm/iwm.cpp
+++ b/lib/bus/iwm/iwm.cpp
@@ -636,10 +636,10 @@ void iwmBus::handle_init()
     }
     // assign dev numbers
     pDevice = (*it);
-    
+    pDevice->switched = false; //reset switched condition on init
+    pDevice->eject_latch = false; //reset eject latch on init
     if (pDevice->id() == 0)
     {
-      pDevice->switched = false; //reset switched condition on init
       pDevice->_devnum = command_packet.dest; // assign address
       if (++it == _daisyChain.end())
         status = 0xff; // end of the line, so status=non zero - to do: check GPIO for another device in the physical daisy chain

--- a/lib/bus/iwm/iwm.h
+++ b/lib/bus/iwm/iwm.h
@@ -286,6 +286,8 @@ protected:
 
 public:
   bool device_active;
+  //eject_latch allows simulation of an empty drive momentarily on disk mounts
+  bool eject_latch = false; 
   bool switched = false; //indicate disk switched condition
   bool readonly = true;  //write protected 
   bool is_config_device;

--- a/lib/device/iwm/disk.cpp
+++ b/lib/device/iwm/disk.cpp
@@ -63,14 +63,15 @@ void iwmDisk::send_status_reply_packet()
   // Bit 1: Currently interrupting (//c only)
   // Bit 0: Disk Switched 
   data[0] = 0b11101000;
-  if(switched) {
+  if((switched) && (!eject_latch)) {
     data[0] |= STATCODE_DISK_SWITCHED;
     switched = false;
     }
-  if(!device_active) {data[0] &= ~(STATCODE_DEVICE_ONLINE);}
+  if((!device_active) || (eject_latch)) {data[0] &= ~(STATCODE_DEVICE_ONLINE);}
   if(device_active) {data[0] |= STATCODE_DEVICE_ONLINE;}
   if(readonly) {data[0] |= STATCODE_WRITE_PROTECT;}
-  Debug_printf("\r\nstatus = %02X\r\n",data[0]);
+  if((_disk != nullptr) && (eject_latch)) {eject_latch = false;}
+  Debug_printf("\r\nsend_status_reply_packet status = %02X\r\n",data[0]);
   data[1] = data[2] = data[3] = 0;
   if (_disk != nullptr)
   {
@@ -94,7 +95,7 @@ void iwmDisk::send_status_reply_packet()
 // data byte 2-5 number of blocks. 2 is the LSB and 5 the MSB.
 // Size determined from image file.
 //*****************************************************************************
-void iwmDisk::send_extended_status_reply_packet()
+void iwmDisk::send_extended_status_reply_packet() //XXX! Currently unused
 {
   uint8_t data[5];
   data[0] = 0b11101000;
@@ -105,7 +106,7 @@ void iwmDisk::send_extended_status_reply_packet()
     switched = false;
     }
   if(readonly) {data[0] |= STATCODE_WRITE_PROTECT;}
-  Debug_printf("\r\n status = %02X\r\n",data[0]);
+  Debug_printf("\r\nsend_extended_status_reply_packet status = %02X\r\n",data[0]);
   // Build the contents of the packet
   // Info byte
   // Bit 7: Block  device
@@ -156,14 +157,10 @@ void iwmDisk::send_status_dib_reply_packet() // to do - abstract this out with p
   // Bit 1: Currently interrupting (//c only)
   // Bit 0: Disk switched
   data[0] = 0b11101000;
-  if(switched) {
-    data[0] |= STATCODE_DISK_SWITCHED;
-    switched = false;
-    }
-  if(!device_active) {data[0] &= ~(STATCODE_DEVICE_ONLINE);}
+  if((!device_active)|| (eject_latch)) {data[0] &= ~(STATCODE_DEVICE_ONLINE);}
   if(device_active) {data[0] |= STATCODE_DEVICE_ONLINE;}
   if(readonly) {data[0] |= STATCODE_WRITE_PROTECT;}
-  Debug_printf("\r\nstatus = %02X\r\n",data[0]);
+  Debug_printf("\r\nsend_status_dib_reply_packet status = %02X\r\n",data[0]);
   data[1] = 0;
   data[2] = 0;
   data[3] = 0;
@@ -214,7 +211,7 @@ void iwmDisk::send_status_dib_reply_packet() // to do - abstract this out with p
 // data byte 2-5 number of blocks. 2 is the LSB and 5 the MSB.
 // Calculated from actual image file size.
 //*****************************************************************************
-void iwmDisk::send_extended_status_dib_reply_packet()
+void iwmDisk::send_extended_status_dib_reply_packet() //XXX! currently unused
 {
   uint8_t data[25];
 
@@ -236,7 +233,7 @@ void iwmDisk::send_extended_status_dib_reply_packet()
   if(!device_active) {data[0] &= ~(STATCODE_DEVICE_ONLINE);}
   if(device_active) {data[0] |= STATCODE_DEVICE_ONLINE;}
   if(readonly) {data[0] |= STATCODE_WRITE_PROTECT;}
-  Debug_printf("\r\nstatus = %02X\r\n",data[0]);
+  Debug_printf("\r\nsend extended DIB replay packet status = %02X\r\n",data[0]);
   data[1] = 0;
   data[2] = 0;
   data[3] = 0;
@@ -341,7 +338,7 @@ void iwmDisk::iwm_readblock(iwm_decoded_cmd_t cmd)
 
   // source = cmd.dest; // we are the destination and will become the source // packet_buffer[6];
   Debug_printf("\r\nDrive %02x ", id());
-  if(switched){
+  if((switched) && (!eject_latch)){
     Debug_printf("iwm_readblock() returning disk switched error\r\n");
     send_reply_packet(SP_ERR_OFFLINE);
     switched = false;
@@ -353,9 +350,11 @@ void iwmDisk::iwm_readblock(iwm_decoded_cmd_t cmd)
     send_reply_packet(SP_ERR_OFFLINE);
     return;
   }
-  if(!device_active) {
+  if((!device_active) || (eject_latch)) {
     Debug_printf("iwm_readblock while device offline!\r\n");
     send_reply_packet(SP_ERR_OFFLINE);
+    if((_disk != nullptr) && (eject_latch))
+      eject_latch = false;
     return;
   }
 
@@ -390,21 +389,8 @@ void iwmDisk::iwm_readblock(iwm_decoded_cmd_t cmd)
 void iwmDisk::iwm_writeblock(iwm_decoded_cmd_t cmd)
 {
   uint8_t status = 0;
-  if(switched) {
-    send_reply_packet(SP_ERR_OFFLINE);
-    switched = false;
-    return;
-  }
- if(!device_active) {
-    Debug_printf("iwm_writeblock while device offline!\r\n");
-    send_reply_packet(SP_ERR_OFFLINE);
-    return;
-  }
- if(readonly) {
-  Debug_printf("\r\niwm_writeblock tried to write while readonly = true!");
-  send_reply_packet(SP_ERR_NOWRITE);
-  return;
- }
+ 
+ 
  //  uint8_t source = cmd.dest; // packet_buffer[6];
   // to do - actually we will already know that the cmd.dest == id(), so can just use id() here
   Debug_printf("\r\nDrive %02x ", id());
@@ -426,7 +412,25 @@ void iwmDisk::iwm_writeblock(iwm_decoded_cmd_t cmd)
   if (data_len == -1)
     iwm_return_ioerror();
   else
-    { // ok
+    { // We have to return the error after ingesting the block to write or ProDOS doesn't correctly see the status. 
+      if((switched) && (!eject_latch)) {
+        send_reply_packet(SP_ERR_OFFLINE);
+        switched = false;
+        return;
+      }
+      if((!device_active) || (eject_latch)) {
+        Debug_printf("iwm_writeblock while device offline!\r\n");
+        send_reply_packet(SP_ERR_OFFLINE);
+        if((_disk != nullptr) && (eject_latch))
+          eject_latch = false;
+        return;
+      } 
+      if(readonly) {
+        Debug_printf("\r\niwm_writeblock tried to write while readonly = true!");
+        send_reply_packet(SP_ERR_NOWRITE);
+        return;
+      }
+
       uint16_t sdstato = BLOCK_DATA_LEN;
       _disk->write(block_num, &sdstato, data_buffer);
       
@@ -474,10 +478,10 @@ mediatype_t iwmDisk::mount(FILE *f, const char *filename, uint32_t disksize, med
   // Destroy any existing MediaType
   if (_disk != nullptr)
   {
-    device_active = false;
-    _disk->unmount();
-    delete _disk;
-    _disk = nullptr;
+    /* We need  first eject the current disk image */
+    unmount(); 
+    eject_latch = true; //simulate the disk ejected for at least one status cycle.
+                        //but only in the case we are mounting over an existing image.
   }
 
     // Determine MediaType based on filename extension
@@ -489,11 +493,10 @@ mediatype_t iwmDisk::mount(FILE *f, const char *filename, uint32_t disksize, med
     case MEDIATYPE_PO:
         Debug_printf("\r\nMedia Type PO");
         device_active = true;
-        switched = true;
+        //switched = true;
         _disk = new MediaTypePO();
         mt = _disk->mount(f, disksize);
         device_active = true; //change status only after we are mounted
-        switched = true;
         //_disk->fileptr() = f;
         // mt = MEDIATYPE_PO;
         break;


### PR DESCRIPTION
… image

 * Simulate an empty drive for one status cycle when mounting one image over the top of another.

 * Change the write block command to report error status only after we've read in the data packet containing the block to write. This is what the host expects and now with this change ProDOS 8 correctly reports a Write Protected error on write protected volumes.

 * reset disk switched/eject latch on INIT unconditionally this prevents problems booting because of the drive reporting offline.