### PR TITLE
Reverted max bytes waiting to 512 for ATARI build

### DIFF
--- a/lib/network-protocol/FS.cpp
+++ b/lib/network-protocol/FS.cpp
@@ -254,7 +254,12 @@ bool NetworkProtocolFS::status_file(NetworkStatus *status)
     if (aux1_open == 8)
         status->rxBytesWaiting = 0;
     else
+#ifdef BUILD_ATARI
+        status->rxBytesWaiting = fileSize > 512 ? 512 : fileSize;
+#else
         status->rxBytesWaiting = fileSize > 65534 ? 65534 : fileSize;
+#endif
+
     status->connected = fileSize > 0 ? 1 : 0;
     status->error = fileSize > 0 ? error : NETWORK_ERROR_END_OF_FILE;
 


### PR DESCRIPTION
For now, revert back to 512 bytes waiting for the Atari while I try to solve the binary loader to handle unlimited bytes waiting.