### PR TITLE
Reliability fixes

### DIFF
--- a/lib/http/httpService.cpp
+++ b/lib/http/httpService.cpp
@@ -873,7 +873,7 @@ esp_err_t fnHttpService::get_handler_dir(httpd_req_t *req)
     unsigned char hs;
     string pattern;
     string chunk;
-
+    char *free_me; //return string from url_encode which must be freed.
     parse_query(req, &qp);
 
     if (qp.query_parsed.find("hostslot") == qp.query_parsed.end())
@@ -928,7 +928,9 @@ esp_err_t fnHttpService::get_handler_dir(httpd_req_t *req)
         if (!qp.query_parsed["path"].empty())
         {
             parent = qp.query_parsed["path"].substr(0, qp.query_parsed["path"].find_last_of("/"));
-            chunk += "<a href=\"/hsdir?hostslot=" + qp.query_parsed["hostslot"] + "&path=" + string(url_encode((char *)parent.c_str())) + "\"><li>&#8617; Parent</li></a>";
+            free_me = url_encode((char *)parent.c_str());
+            chunk += "<a href=\"/hsdir?hostslot=" + qp.query_parsed["hostslot"] + "&path=" + string(free_me) + "\"><li>&#8617; Parent</li></a>";
+            free(free_me);
         }
 
         while ((f = theFuji.get_hosts(hs)->dir_nextfile()) != nullptr)
@@ -937,12 +939,25 @@ esp_err_t fnHttpService::get_handler_dir(httpd_req_t *req)
 
             if (f->isDir == true)
             {
-                chunk += "<a href=\"/hsdir?hostslot=" + qp.query_parsed["hostslot"] + "&path=" + string(url_encode((char *)qp.query_parsed["path"].c_str())) + "%2F" + string(url_encode(f->filename)) + "&parent_path=" + string(url_encode((char *)qp.query_parsed["path"].c_str())) + "\">";
+                free_me = url_encode((char *)qp.query_parsed["path"].c_str());
+                chunk += "<a href=\"/hsdir?hostslot=" + qp.query_parsed["hostslot"] + "&path=" + string(free_me);
+                free(free_me);
+                free_me = url_encode(f->filename);
+                chunk += "%2F" + string(free_me) + "&parent_path=";
+                free(free_me);
+                free_me = url_encode((char *)qp.query_parsed["path"].c_str());
+                chunk += string(free_me) + "\">";
                 chunk += "&#128193; "; // file folder
+                free(free_me);
             }
             else
             {
-                chunk += "<a href=\"/dslot?hostslot=" + qp.query_parsed["hostslot"] + "&filename=" + string(url_encode((char *)qp.query_parsed["path"].c_str())) + "%2F" + string(url_encode(f->filename)) + "\">";
+                free_me = url_encode((char *)qp.query_parsed["path"].c_str());
+                chunk += "<a href=\"/dslot?hostslot=" + qp.query_parsed["hostslot"] + "&filename=" + string(free_me);
+                free(free_me);
+                free_me = url_encode(f->filename);
+                chunk += "%2F" + string(free_me) + "\">";
+                free(free_me);
 
                 if ( // Atari
                     (string(f->filename).find(".atr") != string::npos) ||
@@ -1024,7 +1039,7 @@ esp_err_t fnHttpService::get_handler_slot(httpd_req_t *req)
     queryparts qp;
     string chunk;
     unsigned char hs;
-
+    char *free_me; // return string from url_encode that must be freed.
     chunk.clear();
     parse_query(req, &qp);
 
@@ -1048,7 +1063,9 @@ esp_err_t fnHttpService::get_handler_slot(httpd_req_t *req)
         chunk += "<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\r\n";
         chunk += " <head>\r\n";
         chunk += "  <title>Redirecting to cassette mount</title>";
-        chunk += "  <meta http-equiv=\"refresh\" content=\"0; url=/mount?hostslot=" + qp.query_parsed["hostslot"] + "&deviceslot=7&mode=1&filename=" + string(url_encode((char *)qp.query_parsed["filename"].c_str())) + "\" />";
+        free_me = url_encode((char *)qp.query_parsed["filename"].c_str());
+        chunk += "  <meta http-equiv=\"refresh\" content=\"0; url=/mount?hostslot=" + qp.query_parsed["hostslot"] + "&deviceslot=7&mode=1&filename=" + string(free_me) + "\" />";
+        free(free_me);
         chunk += " </head>\r\n";
         chunk += " <body>\r\n";
         chunk += "  <h1>Cassette detected. Mounting in slot 8.</h1>\r\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -259,6 +259,23 @@ void main_setup()
 // Main high-priority service loop
 void fn_service_loop(void *param)
 {
+       main_setup();
+       // Now that our main service is running, try connecting to WiFi or BlueTooth
+        if (Config.get_bt_status())
+        {
+#ifdef BLUETOOTH_SUPPORT
+            // Start SIO2BT mode if we were in it last shutdown
+            fnLedManager.set(eLed::LED_BT, true); // BT LED ON
+            fnBtManager.start();
+#endif
+        }
+        else if (Config.get_wifi_enabled())
+        {
+            // Set up the WiFi adapter if enabled in config
+            fnWiFi.start();
+            // Go ahead and try reconnecting to WiFi
+            fnWiFi.connect();
+        }
     while (true)
     {
         // We don't have any delays in this loop, so IDLE threads will be starved
@@ -286,7 +303,7 @@ extern "C"
     {
         // cppcheck-suppress "unusedFunction"
         // Call our setup routine
-        main_setup();
+        //main_setup();
 
 // Create a new high-priority task to handle the main loop
 // This is assigned to CPU1; the WiFi task ends up on CPU0
@@ -296,22 +313,6 @@ extern "C"
         xTaskCreatePinnedToCore(fn_service_loop, "fnLoop",
                                 MAIN_STACKSIZE, nullptr, MAIN_PRIORITY, nullptr, MAIN_CPUAFFINITY);
 
-        // Now that our main service is running, try connecting to WiFi or BlueTooth
-        if (Config.get_bt_status())
-        {
-#ifdef BLUETOOTH_SUPPORT
-            // Start SIO2BT mode if we were in it last shutdown
-            fnLedManager.set(eLed::LED_BT, true); // BT LED ON
-            fnBtManager.start();
-#endif
-        }
-        else if (Config.get_wifi_enabled())
-        {
-            // Set up the WiFi adapter if enabled in config
-            fnWiFi.start();
-            // Go ahead and try reconnecting to WiFi
-            fnWiFi.connect();
-        }
 
         // Sit here twiddling our thumbs
         while (true)


### PR DESCRIPTION
This addresses two issues that kept me from doing a full test run of installing gsos from scratch, verifying it and adding extra applications on top while doing many disk swaps from the web UI on a single boot of the fujinet.  

the two problems encountered were: 

- webUI: memory leak that lead to sdmmc errors after enough file navigation was done.
- interrupts allowed in both CPU cores leading to watchdog timeouts obtaining locks held in the opposite core.

