### PR TITLE
remove eject_latch code and try to mimic AppleDisk 3.5 status behavior.

### DIFF
--- a/lib/bus/iwm/iwm.cpp
+++ b/lib/bus/iwm/iwm.cpp
@@ -622,7 +622,6 @@ void iwmBus::handle_init()
     // assign dev numbers
     pDevice = (*it);
     pDevice->switched = false; //reset switched condition on init
-    pDevice->eject_latch = false; //reset eject latch on init
     if (pDevice->id() == 0)
     {
       pDevice->_devnum = command_packet.dest; // assign address

--- a/lib/bus/iwm/iwm.h
+++ b/lib/bus/iwm/iwm.h
@@ -282,8 +282,6 @@ protected:
 
 public:
   bool device_active;
-  //eject_latch allows simulation of an empty drive momentarily on disk mounts
-  bool eject_latch = false; 
   bool switched = false; //indicate disk switched condition
   bool readonly = true;  //write protected 
   bool is_config_device;

--- a/lib/device/iwm/disk.cpp
+++ b/lib/device/iwm/disk.cpp
@@ -440,11 +440,13 @@ void iwmDisk::iwm_writeblock(iwm_decoded_cmd_t cmd)
         return;
       }
       if(switched && readonly) {
+        Debug_printf("iwm_writeblock while readonly and disk switched\r\n");
         send_reply_packet(SP_ERR_NOWRITE);
         switched = false;
         return;
       } 
       if(switched) {
+        Debug_printf("iwm_writeblock while disk switched = true\r\nn");
         send_reply_packet(SP_ERR_OFFLINE);
         switched = false;
         return;
@@ -504,9 +506,7 @@ mediatype_t iwmDisk::mount(FILE *f, const char *filename, uint32_t disksize, med
   {
     /* We need  first eject the current disk image */
     unmount(); 
-    switched = true;
-    eject_latch = false; //simulate the disk ejected for at least one status cycle.
-                        //but only in the case we are mounting over an existing image.
+   switched = true; //set disk switched only if we are mounting over an existing image.  
   }
 
     // Determine MediaType based on filename extension

--- a/lib/device/iwm/fuji.cpp
+++ b/lib/device/iwm/fuji.cpp
@@ -446,9 +446,9 @@ void iwmFuji::debug_tape()
 void iwmFuji::iwm_ctrl_disk_image_umount()
 {
     unsigned char ds = data_buffer[0];//adamnet_recv();
-    
+    if(_fnDisks[ds].disk_dev.device_active)
+      _fnDisks[ds].disk_dev.switched = true;
     _fnDisks[ds].disk_dev.unmount();
-    _fnDisks[ds].disk_dev.switched = true;
     _fnDisks[ds].reset();
 }
 

--- a/lib/device/iwm/fuji.cpp
+++ b/lib/device/iwm/fuji.cpp
@@ -448,6 +448,7 @@ void iwmFuji::iwm_ctrl_disk_image_umount()
     unsigned char ds = data_buffer[0];//adamnet_recv();
     
     _fnDisks[ds].disk_dev.unmount();
+    _fnDisks[ds].disk_dev.switched = true;
     _fnDisks[ds].reset();
 }
 
@@ -1435,5 +1436,18 @@ void iwmFuji::process(iwm_decoded_cmd_t cmd)
   fnLedManager.set(LED_BUS, false);
 }
 
-
+void iwmFuji::handle_ctl_eject(uint8_t spid) {
+  int ds = 255;
+  for(int i = 0; i < MAX_DISK_DEVICES; i++) {
+    if(theFuji.get_disks(i)->disk_dev.id() == spid) {
+      ds = i;
+    }
+  }
+  if(ds != 255 ) {
+    theFuji.get_disks(ds)->reset();
+    Config.clear_mount(ds);
+    Config.save();
+    theFuji._populate_slots_from_config();    
+  }
+}
 #endif /* BUILD_APPLE */

--- a/lib/device/iwm/fuji.h
+++ b/lib/device/iwm/fuji.h
@@ -190,6 +190,7 @@ public:
 
     void image_rotate();
     int get_disk_id(int drive_slot);
+    void handle_ctl_eject(uint8_t spid);
     std::string get_host_prefix(int host_slot);
 
     fujiHost *get_hosts(int i) { return &_fnHosts[i]; }

--- a/lib/http/httpService.cpp
+++ b/lib/http/httpService.cpp
@@ -722,6 +722,9 @@ esp_err_t fnHttpService::get_handler_eject(httpd_req_t *req)
     }
 
     theFuji.get_disks(ds)->disk_dev.unmount();
+    #ifdef BUILD_APPLE
+    theFuji.get_disks(ds)->disk_dev.switched = true;
+    #endif
 #ifdef BUILD_ATARI
     if (theFuji.get_disks(ds)->disk_type == MEDIATYPE_CAS || theFuji.get_disks(ds)->disk_type == MEDIATYPE_WAV)
     {

--- a/lib/http/httpService.cpp
+++ b/lib/http/httpService.cpp
@@ -720,11 +720,11 @@ esp_err_t fnHttpService::get_handler_eject(httpd_req_t *req)
     {
         fnHTTPD.addToErrMsg("<li>deviceslot should be between 0 and 7</li>");
     }
-
-    theFuji.get_disks(ds)->disk_dev.unmount();
     #ifdef BUILD_APPLE
-    theFuji.get_disks(ds)->disk_dev.switched = true;
+    if(theFuji.get_disks(ds)->disk_dev.device_active) //set disk switched only if device was previosly mounted. 
+        theFuji.get_disks(ds)->disk_dev.switched = true;
     #endif
+    theFuji.get_disks(ds)->disk_dev.unmount();
 #ifdef BUILD_ATARI
     if (theFuji.get_disks(ds)->disk_type == MEDIATYPE_CAS || theFuji.get_disks(ds)->disk_type == MEDIATYPE_WAV)
     {


### PR DESCRIPTION
This PR changes disk switched behavior to be more like what I've observed using a real  800k floppy drive. it's much less aggressive at returning offline status on reads, clears switched status earlier but still has some protections in place.  

The one place we don't follow strictly the ApleDisk 3.5 firmware driver behavior is that we check for reading  blocks > 2 when switched = true and if so report offline status and clear switched.  this is to protect reads from the wrong disk being written somewhere and is mainly paranoia on my part. 

if blocks 0 , 1 or 2 are read it clears switched condition and allows the reads for any block on the disk from that point forward. this should keep ProDOS happy, older Installer programs like the ORCA/M installer that don't poll status but read block 2 to detect the volume changes, and also make sure boot is uninhibited regardless of if we've received a bus reset or INIT sequence. 

