### PR TITLE
[iwm] [disk] remember previous type byte when offline.

### DIFF
--- a/lib/bus/iwm/iwm.h
+++ b/lib/bus/iwm/iwm.h
@@ -282,6 +282,7 @@ protected:
 
 public:
   bool device_active;
+  uint8_t prevtype = SP_TYPE_BYTE_HARDDISK; //preserve previous device type when offline
   bool switched = false; //indicate disk switched condition
   bool readonly = true;  //write protected 
   bool is_config_device;


### PR DESCRIPTION
prevent device types changing when finder re-starts if the device happens to have been offline. sometimes the finder cares not only about the volume name but also the type.

We also re-locate the error condition tests in iwm_readblock until after we get our block number so debug messages are easier to reason about.