### PR TITLE
add open/close and update read handling for cpm & modem (a3)

### DIFF
--- a/lib/device/iwm/modem.h
+++ b/lib/device/iwm/modem.h
@@ -191,8 +191,8 @@ private:
     void process(iwm_decoded_cmd_t cmd) override;
 
     void iwm_ctrl(iwm_decoded_cmd_t cmd) override;
-    void iwm_open(iwm_decoded_cmd_t cmd) override{};
-    void iwm_close(iwm_decoded_cmd_t cmd) override{};
+    void iwm_open(iwm_decoded_cmd_t cmd) override;
+    void iwm_close(iwm_decoded_cmd_t cmd) override;
     void iwm_read(iwm_decoded_cmd_t cmd) override;
     void iwm_write(iwm_decoded_cmd_t cmd) override;
     void iwm_status(iwm_decoded_cmd_t cmd) override;


### PR DESCRIPTION
interesting, for read calls, SP supports returning only what it has available for a read. It puts the actual number of bytes returned in X & Y. Works for Liron and softsp. I have not tested in the IIc+, but it may not work there. I'm using this for A3 support as one mode of the standard terminals uses this ask for a lot of bytes, and accept just what is available approach. So only using read calls to poll for data.