### PR TITLE
Add multiple wifi slots

### DIFF
--- a/README_wifi.md
+++ b/README_wifi.md
@@ -6,9 +6,9 @@ In the WiFi UI configuration is an option to enable wifi passphrase encryptiong.
 
 The option will enable/disable wifi passphrase encryption with a key unique to the FUJINET device and offers protection from observation of passphrases in INI files.
 
-The encryption routine is taken from https://github.com/torvalds/uemacs 'micro emacs' and is isomorphic (encrypt/decrypt are mirror functions), as well as giving characters in the ascii domain to ensure no binary gets in the INI file.
+The encryption routine is taken from <https://github.com/torvalds/uemacs> 'micro emacs' and is isomorphic (encrypt/decrypt are mirror functions), as well as giving characters in the ascii domain to ensure no binary gets in the INI file.
 
-# Recovering default state (if shit happens)
+## Recovering default state (if shit happens)
 
 If you somehow change the MAC address of your FUJINET and want to reset back to normal, you can either reset your config (Power ON + B), or change the global `encrypt_passphrase` value back to 0, and using clear text for the passphrase in the INI file, as shown below:
 
@@ -23,8 +23,10 @@ passphrase=your_plaintext_here
 ```
 
 ## Console Monitor Output
+
 Output in serial monitor will show the decryption in action, for example:
-```
+
+```text
 11:15:12.979 > WiFiManager::start() complete
 11:15:13.065 > WIFI_EVENT_STA_START
 11:15:13.065 > Decrypting passphrase

--- a/lib/config/fnConfig.cpp
+++ b/lib/config/fnConfig.cpp
@@ -6,5 +6,15 @@ fnConfig Config;
 // Initialize some defaults
 fnConfig::fnConfig()
 {
+    int i;
+
     strlcpy(_network.sntpserver, CONFIG_DEFAULT_SNTPSERVER, sizeof(_network.sntpserver));
+
+    // clear stored wifi data. The default enabled flag is true which we are using to indicate an entry in stored wifi
+    for (i = 0; i < MAX_WIFI_STORED; i++)
+    {
+        _wifi_stored[i].ssid.clear();
+        _wifi_stored[i].passphrase.clear();
+        _wifi_stored[i].enabled = false;
+    }
 }

--- a/lib/config/fnConfig.h
+++ b/lib/config/fnConfig.h
@@ -10,6 +10,7 @@
 #define MAX_PRINTER_SLOTS 4
 #define MAX_TAPE_SLOTS 1
 #define MAX_PB_SLOTS 16
+#define MAX_WIFI_STORED 8
 
 #define BASE_TAPE_SLOT 0x1A
 
@@ -86,8 +87,9 @@ public:
     std::string get_wifi_passphrase() {
         if (_general.encrypt_passphrase) {
             // crypt is a isomorphic operation, calling it when passphrase is encrypted will decrypt it.
-            Debug_println("Decrypting passphrase");
-            return crypto.crypt(_wifi.passphrase);
+            std::string cleartext = crypto.crypt(_wifi.passphrase);
+            // Debug_printf("Decrypting passphrase >%s< for ssid >%s< with key >%s<, cleartext: >%s<\n", _wifi.passphrase.c_str(), _wifi.ssid.c_str(), crypto.getkey().c_str(), cleartext.c_str());
+            return cleartext;
         } else {
             return _wifi.passphrase;
         }
@@ -97,6 +99,14 @@ public:
     void reset_wifi() { _wifi.ssid.clear(); _wifi.passphrase.clear(); };
     void store_wifi_enabled(bool status);
     bool get_wifi_enabled() { return _wifi.enabled; };
+
+    std::string get_wifi_stored_ssid(int index) { return _wifi_stored[index].ssid; }
+    std::string get_wifi_stored_passphrase(int index) { return _wifi_stored[index].passphrase; }
+    bool get_wifi_stored_enabled(int index) { return _wifi_stored[index].enabled; }
+
+    void store_wifi_stored_ssid(int index, std::string ssid); // { _wifi_stored[index].ssid = ssid; }
+    void store_wifi_stored_passphrase(int index, std::string passphrase);
+    void store_wifi_stored_enabled(int index, bool enabled); // { _wifi_stored[index].enabled = enabled; }
 
     // BLUETOOTH
     void store_bt_status(bool status);
@@ -190,6 +200,7 @@ private:
 
     void _read_section_general(std::stringstream &ss);
     void _read_section_wifi(std::stringstream &ss);
+    void _read_section_wifi_stored(std::stringstream &ss, int index);
     void _read_section_bt(std::stringstream &ss);
     void _read_section_network(std::stringstream &ss);
     void _read_section_host(std::stringstream &ss, int index);
@@ -206,6 +217,7 @@ private:
     {
         SECTION_GENERAL,
         SECTION_WIFI,
+        SECTION_WIFI_STORED,
         SECTION_BT,
         SECTION_HOST,
         SECTION_MOUNT,
@@ -347,6 +359,7 @@ private:
     mount_info _mount_slots[MAX_MOUNT_SLOTS];
     printer_info _printer_slots[MAX_PRINTER_SLOTS];
     mount_info _tape_slots[MAX_TAPE_SLOTS];
+    wifi_info _wifi_stored[MAX_WIFI_STORED];
 
     wifi_info _wifi;
     bt_info _bt;

--- a/lib/config/fnc_general.cpp
+++ b/lib/config/fnc_general.cpp
@@ -54,9 +54,16 @@ void fnConfig::store_general_encrypt_passphrase(bool encrypt_passphrase)
     // It changed, so either we were encrypting before and it needs decrypting, or v.v.
     // Either way, we will simply reverse the buffer, as enc/dec are isomorphic
     _wifi.passphrase = crypto.crypt(_wifi.passphrase);
-    // Debug_printf("fnConfig::store_general_encrypt_passphrase passphrase is now: >%s<\n", _wifi.passphrase.c_str());
-    // Debug_printf("fnConfig::store_general_encrypt_passphrase setting _general.encrypt_passphrase to %d\n", encrypt_passphrase);
     _general.encrypt_passphrase = encrypt_passphrase;
+
+    // Do the same to any enabled stored wifi configs
+    for (int i = 0; i < MAX_WIFI_STORED; i++)
+    {
+        if (_wifi_stored[i].enabled) {
+            _wifi_stored[i].passphrase = crypto.crypt(_wifi_stored[i].passphrase);
+        }
+    }
+
     _dirty = true;
     
 }

--- a/lib/config/fnc_load.cpp
+++ b/lib/config/fnc_load.cpp
@@ -125,6 +125,9 @@ New behavior: copy from SD first if available, then read SPIFFS.
         case SECTION_WIFI:
             _read_section_wifi(ss);
             break;
+        case SECTION_WIFI_STORED:
+            _read_section_wifi_stored(ss, index);
+            break;
         case SECTION_BT:
             _read_section_bt(ss);
             break;

--- a/lib/config/fnc_save.cpp
+++ b/lib/config/fnc_save.cpp
@@ -11,6 +11,7 @@
 */
 void fnConfig::save()
 {
+    int i;
 
     Debug_println("fnConfig::save");
 
@@ -39,13 +40,26 @@ void fnConfig::save()
     ss << "printer_enabled=" << _general.printer_enabled << LINETERM;
     ss << "encrypt_passphrase=" << _general.encrypt_passphrase << LINETERM;
 
-    ss << LINETERM;
+    // ss << LINETERM;
 
     // WIFI
     ss << LINETERM << "[WiFi]" LINETERM;
     ss << "enabled=" << _wifi.enabled << LINETERM;
     ss << "SSID=" << _wifi.ssid << LINETERM;
     ss << "passphrase=" << _wifi.passphrase << LINETERM;
+
+    // WIFI STORED
+    for (i = 0; i < MAX_WIFI_STORED; i++)
+    {
+        if (_wifi_stored[i].enabled)
+        {
+            ss << LINETERM << "[WiFiStored" << (i + 1) << "]" LINETERM;
+            ss << "SSID=" << _wifi_stored[i].ssid << LINETERM;
+            ss << "passphrase=" << _wifi_stored[i].passphrase << LINETERM;
+        }
+        else
+            break;
+    }
 
     // BLUETOOTH
     ss << LINETERM << "[Bluetooth]" LINETERM;
@@ -58,7 +72,6 @@ void fnConfig::save()
     ss << "sntpserver=" << _network.sntpserver << LINETERM;
 
     // HOSTS
-    int i;
     for (i = 0; i < MAX_HOST_SLOTS; i++)
     {
         if (_host_slots[i].type != HOSTTYPE_INVALID)

--- a/lib/config/fnc_util.cpp
+++ b/lib/config/fnc_util.cpp
@@ -53,6 +53,16 @@ fnConfig::section_match fnConfig::_find_section_in_line(std::string &line, int &
                 //Debug_printf("Found PRINTER %d\n", index);
                 return SECTION_PRINTER;
             }
+            if (strncasecmp("WiFiStored", s1.c_str(), 10) == 0)
+            {
+                index = atoi((const char *)(s1.c_str() + 10)) - 1;
+                if (index < 0 || index >= MAX_WIFI_STORED)
+                {
+                    Debug_println("Invalid index value - discarding");
+                    return SECTION_UNKNOWN;
+                }
+                return SECTION_WIFI_STORED;
+            }
             else if (strncasecmp("WiFi", s1.c_str(), 4) == 0)
             {
                 //Debug_printf("Found WIFI\n");

--- a/lib/config/fnc_wifi.cpp
+++ b/lib/config/fnc_wifi.cpp
@@ -54,6 +54,8 @@ void fnConfig::store_wifi_enabled(bool status)
 
 void fnConfig::_read_section_wifi(std::stringstream &ss)
 {
+    Debug_println("Reading wifi section");
+
     // Throw out any existing data
     _wifi.ssid.clear();
     _wifi.passphrase.clear();
@@ -62,10 +64,14 @@ void fnConfig::_read_section_wifi(std::stringstream &ss)
     // Read lines until one starts with '[' which indicates a new section
     while (_read_line(ss, line, '[') >= 0)
     {
+        // Debug_printf("wifi line: >%s<\n", line.c_str());
         std::string name;
         std::string value;
         if (_split_name_value(line, name, value))
         {
+            // Debug_printf(" name: >%s<\n", name.c_str());
+            // Debug_printf("value: >%s<\n", value.c_str());
+
             if (strcasecmp(name.c_str(), "SSID") == 0)
             {
                 _wifi.ssid = value;
@@ -83,4 +89,54 @@ void fnConfig::_read_section_wifi(std::stringstream &ss)
             }
         }
     }
+}
+
+void fnConfig::_read_section_wifi_stored(std::stringstream &ss, int index)
+{
+    Debug_printf("Reading stored wifi section for index: %d\n", index);
+
+    _wifi_stored[index].ssid.clear();
+    _wifi_stored[index].passphrase.clear();
+    _wifi_stored[index].enabled = false;
+
+    std::string line;
+    // Read lines until one starts with '[' which indicates a new section
+    while (_read_line(ss, line, '[') >= 0)
+    {
+        std::string name;
+        std::string value;
+        // If there's a section, it means it's 'enabled' - we're borrowing the wifi_info structure for alternate purpose
+        _wifi_stored[index].enabled = true;
+
+        if (_split_name_value(line, name, value))
+        {
+            if (strcasecmp(name.c_str(), "SSID") == 0)
+            {
+                _wifi_stored[index].ssid = value;
+            }
+            else if (strcasecmp(name.c_str(), "passphrase") == 0)
+            {
+                _wifi_stored[index].passphrase = value;
+            }
+        }
+    }
+}
+
+void fnConfig::store_wifi_stored_ssid(int index, std::string ssid)
+{ 
+    _wifi_stored[index].ssid = ssid;
+    _dirty = true;
+}
+
+void fnConfig::store_wifi_stored_passphrase(int index, std::string passphrase)
+{
+    // TODO: check if encryption is an issue here. Should be coming from previous "current" config, which will already be encrypted if enabled.
+    _wifi_stored[index].passphrase = passphrase;
+    _dirty = true;
+}
+
+void fnConfig::store_wifi_stored_enabled(int index, bool enabled)
+{ 
+    _wifi_stored[index].enabled = enabled;
+    _dirty = true;
 }

--- a/lib/encrypt/crypt.h
+++ b/lib/encrypt/crypt.h
@@ -22,6 +22,7 @@ public:
     // crypt/decrypt are isomorphic, and just reverse the process
     std::string crypt(std::string t);
     void setkey(std::string key) { _key = key; }
+    std::string getkey() { return _key; }
 };
 
 extern Crypto crypto;

--- a/lib/hardware/fnWiFi.cpp
+++ b/lib/hardware/fnWiFi.cpp
@@ -10,6 +10,7 @@
 #include <mdns.h>
 
 #include <cstring>
+#include <algorithm>
 
 #include "../../include/debug.h"
 
@@ -110,8 +111,18 @@ int WiFiManager::start()
 // Attempts to connect using information in Config (if any)
 int WiFiManager::connect()
 {
-    if (Config.have_wifi_info())
+    if (Config.have_wifi_info()) {
+        _all_stored_failed = false;
+        _stored_index = 0;
+        _trying_stored = false;
+
+        // Check if main config works
+        Debug_println("WiFiManager attempting to connect:");
+        Debug_printf("ssid = %s\n", Config.get_wifi_ssid().c_str());
+        // Debug_printf("pass = %s\n", Config.get_wifi_passphrase().c_str());
+
         return connect(Config.get_wifi_ssid().c_str(), Config.get_wifi_passphrase().c_str());
+    }
     else
         return -1;
 }
@@ -130,8 +141,12 @@ int WiFiManager::connect(const char *ssid, const char *password)
             if (current_ssid.compare(ssid) != 0)
             {
                 Debug_printf("Disconnecting from current SSID \"%s\"\n", current_ssid.c_str());
+                _disconnecting = true;
                 esp_wifi_disconnect();
+                // Must delay before changing our disconnecting flag, as the network tries to reconnect before completing the new connection
+                // and uses the old settings still, and connecting you to the wrong (old) wifi details.
                 fnSystem.delay(500);
+                _disconnecting = false;
             }
         }
 
@@ -187,7 +202,9 @@ uint8_t WiFiManager::scan_networks(uint8_t maxresults)
     if (_connected == true)
     {
         temporary_disconnect = true;
+        _disconnecting = true;
         esp_wifi_disconnect();
+        _disconnecting = false;
     }
 
     _scan_in_progress = true;
@@ -469,6 +486,7 @@ void WiFiManager::_wifi_event_handler(void *arg, esp_event_base_t event_base,
 {
     // Get a pointer to our fnWiFi object
     WiFiManager *pFnWiFi = (WiFiManager *)arg;
+    int connection_attempts = FNWIFI_RECONNECT_RETRIES;
 
     // IP_EVENT NOTIFICATIONS
     if (event_base == IP_EVENT)
@@ -524,6 +542,36 @@ void WiFiManager::_wifi_event_handler(void *arg, esp_event_base_t event_base,
         case WIFI_EVENT_STA_CONNECTED:
             Debug_println("WIFI_EVENT_STA_CONNECTED");
             pFnWiFi->_reconnect_attempts = 0;
+            if (pFnWiFi->_trying_stored)
+            {
+                // we were trying stored values, and found a good connection
+                int i = pFnWiFi->_matched_wifis.at(pFnWiFi->_stored_index).index;
+                Debug_printf("Found stored entry to connect to. Shuffling everything above %d down 1\n", i);
+
+                // copy the values that worked
+                std::string working_ssid = Config.get_wifi_stored_ssid(i);
+                std::string working_passphrase = Config.get_wifi_stored_passphrase(i);
+
+                // shuffle the old stored wifi entries down 1 position until hit the found stored wifi
+                for (int j = i - 1; j >= 0; j--)
+                {
+                    Config.store_wifi_stored_ssid(j + 1, Config.get_wifi_stored_ssid(j));
+                    Config.store_wifi_stored_passphrase(j + 1, Config.get_wifi_stored_passphrase(j));
+                    Config.store_wifi_stored_enabled(j + 1, true); // Always true as we're copying down the stack of stored configs
+                }
+
+                // move the old config into pos 0 so it's tried first next time.
+                Config.store_wifi_stored_ssid(0, Config.get_wifi_ssid());
+                Config.store_wifi_stored_passphrase(0, Config.get_wifi_passphrase());
+                Config.store_wifi_stored_enabled(0, true);
+
+                // store working values into current config
+                Config.store_wifi_ssid(working_ssid.c_str(), working_ssid.length());
+                Config.store_wifi_passphrase(working_passphrase.c_str(), working_passphrase.length());
+
+                // save our changes
+                Config.save();
+            }
             break;
         // Set WiFi to disconnected
         case WIFI_EVENT_STA_DISCONNECTED:
@@ -532,13 +580,55 @@ void WiFiManager::_wifi_event_handler(void *arg, esp_event_base_t event_base,
                 Debug_println("WIFI_EVENT_STA_DISCONNECTED");
                 pFnWiFi->handle_station_stop();
             }
+
+            // if we are currently attempting to disconnect, don't attempt to reconnect
+            if (pFnWiFi->_disconnecting) return;
+
             // Try to reconnect
             if (pFnWiFi->_scan_in_progress == false &&
-                pFnWiFi->_reconnect_attempts < FNWIFI_RECONNECT_RETRIES && Config.have_wifi_info())
+                pFnWiFi->_reconnect_attempts < connection_attempts && Config.have_wifi_info())
             {
                 pFnWiFi->_reconnect_attempts++;
-                Debug_printf("WiFi reconnect attempt %u of %d\n", pFnWiFi->_reconnect_attempts, FNWIFI_RECONNECT_RETRIES);
+                Debug_printf("WiFi reconnect attempt %u of %d\n", pFnWiFi->_reconnect_attempts, connection_attempts);
                 esp_wifi_connect();
+            }
+            else if (pFnWiFi->_scan_in_progress == false &&
+                pFnWiFi->_reconnect_attempts == connection_attempts && Config.have_wifi_info() && !pFnWiFi->_trying_stored)
+            {
+                // we have tried the current wifi config but it failed.
+                // Start trying stored configs if there are any.
+                // If we haven't yet scanned the network for bssids, do so, then match any with our current stored entries
+                // as it's pointless trying to connect to anything not seen by network, as it clearly won't connect.
+                // TODO: will this stop us connecting to hidden wifis? is that even possible?
+
+                vector<string> network_names = pFnWiFi->get_network_names();
+                vector<WiFiManager::stored_wifi> stored_wifis = pFnWiFi->get_stored_wifis();
+                vector<stored_wifi> common_names = pFnWiFi->match_stored_with_network_wifis(network_names, stored_wifis);
+
+                // copy the common names to our manager to iterate over
+                std::copy(common_names.begin(), common_names.end(), std::back_inserter(pFnWiFi->_matched_wifis));
+
+                // no entries in common between stored and seen networks
+                if (common_names.empty()) return;
+
+                pFnWiFi->_trying_stored = true;
+                pFnWiFi->_reconnect_attempts = 0;
+
+                Debug_printf("Trying wifi stored config 0, SSID: %s\n", common_names.at(0).ssid);
+                pFnWiFi->connect(common_names.at(0).ssid, Config.get_wifi_stored_passphrase(common_names.at(0).index).c_str());
+            }
+            else if (pFnWiFi->_scan_in_progress == false &&
+                pFnWiFi->_reconnect_attempts == connection_attempts && Config.have_wifi_info() && pFnWiFi->_trying_stored)
+            {
+                // Try next common if available
+                pFnWiFi->_reconnect_attempts = 0;
+                pFnWiFi->_stored_index++;
+                int i = pFnWiFi->_stored_index;
+                if (i < pFnWiFi->_matched_wifis.size())
+                {
+                    Debug_printf("Trying wifi stored config %d, SSID: %s\n", i, pFnWiFi->_matched_wifis.at(i).ssid);
+                    pFnWiFi->connect(pFnWiFi->_matched_wifis.at(i).ssid, Config.get_wifi_stored_passphrase(pFnWiFi->_matched_wifis.at(i).index).c_str());
+                }
             }
             break;
         case WIFI_EVENT_STA_AUTHMODE_CHANGE:
@@ -546,4 +636,77 @@ void WiFiManager::_wifi_event_handler(void *arg, esp_event_base_t event_base,
             break;
         }
     }
+}
+
+std::vector<std::string> WiFiManager::get_network_names()
+{
+    struct
+    {
+        char ssid[MAX_SSID_LEN+1];
+        uint8_t rssi;
+    } detail;
+
+    std::vector<std::string> network_names;
+    if (_scan_record_count == 0) {
+        // get the names of the networks in range, as we haven't done it yet
+        scan_networks();
+        _scan_in_progress = false;
+    }
+    for (int i = 0; i < _scan_record_count; i++) {
+        get_scan_result(i, detail.ssid, &detail.rssi);
+        network_names.push_back(detail.ssid);
+    }
+
+    return network_names;
+}
+
+std::vector<WiFiManager::stored_wifi> WiFiManager::get_stored_wifis()
+{
+    vector<WiFiManager::stored_wifi> stored_wifis;
+    int i;
+    for ( i = 0; i < MAX_WIFI_STORED; i++)
+    {
+        if(Config.get_wifi_stored_enabled(i))
+        {
+            WiFiManager::stored_wifi d;
+            strcpy(d.ssid, Config.get_wifi_stored_ssid(i).c_str());
+            d.index = i;
+            stored_wifis.push_back(d);
+        }
+    }
+    return stored_wifis;
+}
+
+std::vector<WiFiManager::stored_wifi> WiFiManager::match_stored_with_network_wifis(std::vector<std::string> network_names, std::vector<WiFiManager::stored_wifi> stored_wifis)
+{
+    Debug_printf("Found following networks:\n");
+    for (string _network_name: network_names)
+    {
+        Debug_printf(" - %s\n", _network_name.c_str());
+    }
+
+    Debug_printf("Found following stored networks:\n");
+    for (stored_wifi d: stored_wifis)
+    {
+        Debug_printf(" - %s, index: %d\n", d.ssid, d.index);
+    }
+
+    vector<stored_wifi> common_names;
+    // We are not using set_intersect() as it requires the lists to be sorted but we want to preserve the stored names order
+
+    for (stored_wifi d: stored_wifis)
+    {
+        if (std::find(network_names.begin(), network_names.end(), d.ssid) != network_names.end())
+        {
+            common_names.push_back(d);
+        }
+    }
+
+    Debug_printf("Common names:\n");
+    for (stored_wifi d: common_names)
+    {
+        Debug_printf(" - %s, index: %d\n", d.ssid, d.index);
+    }
+
+    return common_names;
 }

--- a/lib/hardware/fnWiFi.h
+++ b/lib/hardware/fnWiFi.h
@@ -7,16 +7,25 @@
 #include <esp_wifi.h>
 
 #include <string>
+#include <vector>
 
-
-#define FNWIFI_RECONNECT_RETRIES 8
+#define FNWIFI_RECONNECT_RETRIES 4
 #define FNWIFI_SCAN_RESULTS_MAX 20
 #define FNWIFI_BIT_CONNECTED BIT0
+
+// using namespace std;
 
 class WiFiManager
 {
 private:
-    bool _started = false;
+     struct stored_wifi
+    {
+        char ssid[MAX_SSID_LEN+1];
+        int index;
+        // bool enabled;
+    };
+
+   bool _started = false;
     bool _connected = false;
     std::string _ssid;
     std::string _password;
@@ -26,6 +35,7 @@ private:
     wifi_ap_record_t * _scan_records = nullptr;
     uint16_t _scan_record_count = 0;
     bool _scan_in_progress = false;
+    bool _disconnecting = false;
 
     uint16_t _reconnect_attempts = 0;
 
@@ -35,6 +45,16 @@ private:
                                     int32_t event_id, void *event_data);
     EventGroupHandle_t _wifi_event_group;
     int remove_duplicate_scan_results(wifi_ap_record_t scan_records[], uint16_t record_count);
+
+    bool _trying_stored = false;
+    uint16_t _stored_index = 0;
+    bool _all_stored_failed = false;
+    uint16_t _common_index = 0;
+    std::vector<stored_wifi> _matched_wifis;
+
+    std::vector<std::string> get_network_names();
+    std::vector<stored_wifi> get_stored_wifis();
+    std::vector<stored_wifi> match_stored_with_network_wifis(std::vector<std::string> network_names, std::vector<stored_wifi> stored_wifis);
 
 public:
     int retries;

--- a/lib/hardware/keys.cpp
+++ b/lib/hardware/keys.cpp
@@ -315,6 +315,7 @@ void KeyManager::_keystate_task(void *param)
             sio_message_t msg;
             msg.message_id = SIOMSG_DEBUG_TAPE;
             xQueueSend(SIO.qSioMessages, &msg, 0);
+
 #endif /* BUILD_ATARI */
             break;
         case eKeyStatus::DOUBLE_TAP:


### PR DESCRIPTION
This fixes #493

The fuji will attempt to connect to the currently configured wifi, and if that fails will attempt to match any networks against stored entries, and try them in order of saved config which means it will try the last one it was able to connect to first if more than one network is found.

This means if you're constantly in range of multiple devices, you can't currently pick the second one without removing the entry for the other. This could be a future enhancement if needed.

Note it will only attempt to connect to something that is visible from a network scan and ignore other saved entries (which massively speeds up the process of connecting to one of the stored entries).

For new networks, as they are added, old networks are pushed down the 'stack' of old wifi configs until a max is reached, at which point they drop off the end. The pushed down networks are tried again when the current cannot be connected to as detailed above.