### PR TITLE
rc2014: build: update to platformio esp platform 6.1

### DIFF
--- a/lib/bus/rc2014bus/rc2014bus.h
+++ b/lib/bus/rc2014bus/rc2014bus.h
@@ -8,6 +8,7 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>
 #include <vector>
+#include <string>
 
 #include <map>
 

--- a/lib/device/rc2014/printer.h
+++ b/lib/device/rc2014/printer.h
@@ -20,7 +20,7 @@ class rc2014Printer : public virtualDevice
 {
 protected:
     // SIO THINGS
-    TaskHandle_t *thPrinter;
+    TaskHandle_t thPrinter;
 
     static constexpr int TX_BUF_SIZE = 256;
 

--- a/lib/device/rc2014/rc2014cpm.h
+++ b/lib/device/rc2014/rc2014cpm.h
@@ -7,11 +7,6 @@
 
 #define FOLDERCHAR '/'
 
-// Silly typedefs that runcpm uses
-typedef uint8_t uint8;
-typedef uint16_t uint16;
-typedef uint32_t uint32;
-
 class rc2014CPM : public virtualDevice
 {
 private:


### PR DESCRIPTION
The update to platformio ESP32 platform causes a couple of new compiling issues. Fix them.