### PR TITLE
Fix BUILD_COCO ifdef and other BUILD_ comments

### DIFF
--- a/lib/device/comlynx/udpstream.cpp
+++ b/lib/device/comlynx/udpstream.cpp
@@ -84,4 +84,4 @@ void lynxUDPStream::comlynx_process(uint8_t b)
     return;
 }
 
-#endif /* BUILD_ATARI */
+#endif /* BUILD_LYNX */

--- a/lib/device/cx16_i2c/printer.cpp
+++ b/lib/device/cx16_i2c/printer.cpp
@@ -301,4 +301,4 @@ void cx16Printer::process(uint32_t commanddata, uint8_t checksum)
     }
 }
 
-#endif /* BUILD_ATARI */
+#endif /* BUILD_CX16 */

--- a/lib/device/drivewire/cassette.cpp
+++ b/lib/device/drivewire/cassette.cpp
@@ -1,4 +1,4 @@
-#ifdef BUILD_ATARI
+#ifdef BUILD_COCO
 
 #include "cassette.h"
 
@@ -656,4 +656,4 @@ uint8_t sioCassette::decode_fsk()
     // #endif
     return out;
 }
-#endif /* BUILD_ATARI */
+#endif /* BUILD_COCO */

--- a/lib/device/drivewire/clock.cpp
+++ b/lib/device/drivewire/clock.cpp
@@ -9,4 +9,4 @@
 void drivewireClock::drivewire_process(uint32_t commanddata, uint8_t checksum)
 {
 }
-#endif /* BUILD_ATARI */
+#endif /* BUILD_COCO */

--- a/lib/device/drivewire/fuji.cpp
+++ b/lib/device/drivewire/fuji.cpp
@@ -1838,4 +1838,4 @@ std::string drivewireFuji::get_host_prefix(int host_slot)
     return _fnHosts[host_slot].get_prefix();
 }
 
-#endif /* BUILD_ATARI */
+#endif /* BUILD_COCO */

--- a/lib/device/drivewire/network.cpp
+++ b/lib/device/drivewire/network.cpp
@@ -477,4 +477,4 @@ void drivewireNetwork::drivewire_do_idempotent_command_80()
 {
 }
 
-#endif /* BUILD_ATARI */
+#endif /* BUILD_COCO */

--- a/lib/device/drivewire/printer.cpp
+++ b/lib/device/drivewire/printer.cpp
@@ -174,4 +174,4 @@ void drivewirePrinter::drivewire_process(uint32_t commanddata, uint8_t checksum)
 {
 }
 
-#endif /* BUILD_ATARI */
+#endif /* BUILD_COCO */

--- a/lib/device/iwm/clock.cpp
+++ b/lib/device/iwm/clock.cpp
@@ -186,4 +186,4 @@ void iwmClock::shutdown()
 
 
 
-#endif /* BUILD_APPLE2 */
+#endif /* BUILD_APPLE */

--- a/lib/device/iwm/cpm.cpp
+++ b/lib/device/iwm/cpm.cpp
@@ -328,4 +328,4 @@ void iwmCPM::shutdown()
     // TODO: clean shutdown.
 }
 
-#endif /* BUILD_APPLE2 */
+#endif /* BUILD_APPLE */

--- a/lib/device/iwm/network.cpp
+++ b/lib/device/iwm/network.cpp
@@ -977,4 +977,4 @@ void iwmNetwork::iwmnet_set_timer_rate()
     // iwmnet_complete();
 }
 
-#endif /* BUILD_iwm */
+#endif /* BUILD_APPLE */

--- a/lib/device/rs232/apetime.cpp
+++ b/lib/device/rs232/apetime.cpp
@@ -109,4 +109,4 @@ void rs232ApeTime::rs232_process(uint32_t commanddata, uint8_t checksum)
         break;
     };
 }
-#endif /* BUILD_ATARI */
+#endif /* BUILD_RS232 */

--- a/lib/device/rs232/disk.cpp
+++ b/lib/device/rs232/disk.cpp
@@ -298,4 +298,4 @@ void rs232Disk::rs232_process(uint32_t commanddata, uint8_t checksum)
     rs232_nak();
 }
 
-#endif /* BUILD_ATARI */
+#endif /* BUILD_RS232 */

--- a/lib/device/rs232/fuji.cpp
+++ b/lib/device/rs232/fuji.cpp
@@ -1623,4 +1623,4 @@ std::string rs232Fuji::get_host_prefix(int host_slot)
     return _fnHosts[host_slot].get_prefix();
 }
 
-#endif /* BUILD_ATARI */
+#endif /* BUILD_RS232 */

--- a/lib/device/rs232/modem.cpp
+++ b/lib/device/rs232/modem.cpp
@@ -1873,4 +1873,4 @@ void rs232Modem::rs232_process(uint32_t commanddata, uint8_t checksum)
     }
 }
 
-#endif /* BUILD_ATARI */
+#endif /* BUILD_RS232 */

--- a/lib/device/rs232/network.cpp
+++ b/lib/device/rs232/network.cpp
@@ -1061,4 +1061,4 @@ void rs232Network::rs232_do_idempotent_command_80()
         rs232_complete();
 }
 
-#endif /* BUILD_ATARI */
+#endif /* BUILD_RS232 */

--- a/lib/device/rs232/printer.cpp
+++ b/lib/device/rs232/printer.cpp
@@ -303,4 +303,4 @@ void rs232Printer::rs232_process(uint32_t commanddata, uint8_t checksum)
     }
 }
 
-#endif /* BUILD_ATARI */
+#endif /* BUILD_RS232 */

--- a/lib/device/rs232/printerlist.cpp
+++ b/lib/device/rs232/printerlist.cpp
@@ -51,4 +51,4 @@ int printerlist::get_port(int index)
     return _printers[index].port;
 }
 
-#endif /* BUILD_ATARI */
+#endif /* BUILD_RS232 */

--- a/lib/device/rs232/rs232cpm.cpp
+++ b/lib/device/rs232/rs232cpm.cpp
@@ -90,4 +90,4 @@ void rs232CPM::rs232_process(uint32_t commanddata, uint8_t checksum)
     }
 }
 
-#endif /* BUILD_ATARI */
+#endif /* BUILD_RS232 */


### PR DESCRIPTION
lib/device/drivewire had an incorrect ifdef to ATARI still for cassette code, causing it to be picked over sio.

other BUILD_ comments also fixed.