### PR TITLE
Tcp server and spiffs

### DIFF
--- a/lib/FileSystem/fnFsSPIFFS.cpp
+++ b/lib/FileSystem/fnFsSPIFFS.cpp
@@ -156,7 +156,8 @@ bool FileSystemSPIFFS::start()
 
     esp_vfs_spiffs_conf_t conf = {
       .base_path = _basepath,
-      .partition_label = "flash",
+      // .partition_label = "flash", // Changing to "flash" causes my FN to cycle error.
+      .partition_label = NULL,
       .max_files = 10, // from SPIFFS.h
       .format_if_mount_failed = false
     };

--- a/lib/modem/modem.cpp
+++ b/lib/modem/modem.cpp
@@ -583,9 +583,15 @@ void modem::sio_listen()
         sio_ack();
 
     tcpServer.setMaxClients(1);
-    tcpServer.begin(listenPort);
-
-    sio_complete();
+    int res = tcpServer.begin(listenPort);
+    if (res == 0)
+    {
+        sio_error();
+    }
+    else
+    {
+        sio_complete();
+    }
 }
 
 /**
@@ -827,11 +833,20 @@ void modem::at_handle_port()
 
         listenPort = port;
         tcpServer.setMaxClients(1);
-        tcpServer.begin(listenPort);
-        if (numericResultCode == true)
-            at_cmd_resultCode(RESULT_CODE_OK);
-        else
-            at_cmd_println("OK");
+        int res = tcpServer.begin(listenPort);
+        if (res == 0)
+        {
+            if (numericResultCode == true)
+                at_cmd_resultCode(RESULT_CODE_ERROR);
+            else
+                at_cmd_println("ERROR");
+        }
+        else {
+            if (numericResultCode == true)
+                at_cmd_resultCode(RESULT_CODE_OK);
+            else
+                at_cmd_println("OK");
+        }
     }
 }
 

--- a/lib/network-protocol/TCP.cpp
+++ b/lib/network-protocol/TCP.cpp
@@ -310,17 +310,16 @@ bool NetworkProtocolTCP::open_server(unsigned short port)
     Debug_printf("Binding to port %d\r\n", port);
 
     server = new fnTcpServer(port);
-    server->begin(port);
-    connectionIsServer = true;
-
-    Debug_printf("errno = %u\r\n", errno);
-
-    if (errno == 0)
-        error = 1;
-    else
+    int res = server->begin(port);
+    connectionIsServer = true;      // set even if we're in error
+    if (res == 0)
+    {
+        Debug_printf("errno = %u\r\n", errno);
         errno_to_error();
+        return true;
+    }
 
-    return errno != 0;
+    return false;
 }
 
 /**
@@ -373,7 +372,7 @@ bool NetworkProtocolTCP::special_accept_connection()
             remoteIP = client.remoteIP();
             remotePort = client.remotePort();
             remoteIPString = inet_ntoa(remoteIP);
-            Debug_printf("Accepted connection from %s:%u", remoteIPString, remotePort);
+            Debug_printf("Accepted connection from %s:%u\r\n", remoteIPString, remotePort);
             return false;
         }
         else


### PR DESCRIPTION
This adds the missing tcpServer.begin bits, and reverts the change to spiffs config from "flash" to NULL.