### PR TITLE
Fix sending all bytes of file and don't abort if ATN is asserted immediately after EOI

### DIFF
--- a/lib/bus/iec/protocol/iecProtocolSerial.cpp
+++ b/lib/bus/iec/protocol/iecProtocolSerial.cpp
@@ -296,11 +296,11 @@ int16_t IecProtocolSerial::receiveByte()
     // happened. If EOI was sent or received in this last transmission, both talker and listener "letgo."  After a suitable pause,
     // the Clock and Data lines are RELEASED to false and transmission stops.
 
-    if ( IEC.flags & EOI_RECVD )
+    if ( IEC.flags & EOI_RECVD
+	 && wait ( TIMING_Tfr )
+	 && (IEC.status( PIN_IEC_ATN ) == RELEASED) )
     {
-        // EOI Received
-        if ( !wait ( TIMING_Tfr ) ) return -1;
-        IEC.release ( PIN_IEC_DATA_OUT );
+	IEC.release ( PIN_IEC_DATA_OUT );
     }
 
     timeoutWait( PIN_IEC_CLK_IN, RELEASED, TIMING_Tbb);

--- a/lib/device/iec/disk.cpp
+++ b/lib/device/iec/disk.cpp
@@ -949,7 +949,7 @@ void iecDisk::sendListing()
 
 bool iecDisk::sendFile()
 {
-    size_t i = 0;
+    size_t count = 0;
     bool success_rx = true;
     bool success_tx = true;
 
@@ -1003,15 +1003,14 @@ bool iecDisk::sendFile()
     if( IEC.data.channel == CHANNEL_LOAD )
     {
         // Get/Send file load address
-        i = 2;
+        count = 2;
         istream->read(&b, 1);
         success_tx = IEC.sendByte(b);
         load_address = b & 0x00FF; // low byte
-        sys_address = b;
         istream->read(&b, 1);
         success_tx = IEC.sendByte(b);
         load_address = load_address | b << 8;  // high byte
-        sys_address += b * 256;
+        sys_address = load_address;
         Debug_printv( "load_address[$%.4X] sys_address[%d]", load_address, sys_address );
 
         // Get SYSLINE
@@ -1036,14 +1035,13 @@ bool iecDisk::sendFile()
         }
 #endif
         // Send Byte
-        avail = istream->available();
-        if ( !avail || !success_rx )
+        if ( count + 1 == avail || !success_rx )
         {
-            //Debug_printv("b[%02X] EOI", b);
+	  //Debug_printv("b[%02X] EOI %i", b, count);
             success_tx = IEC.sendByte(b, true); // indicate end of file.
             if ( !success_tx )
                 Debug_printv("tx fail");
-            
+
             break;
         }
         else
@@ -1054,10 +1052,10 @@ bool iecDisk::sendFile()
                 Debug_printv("tx fail");
                 //break;
             }
-                
+
         }
         b = nb; // byte = next byte
-        i++;
+        count++;
 
 #ifdef DATA_STREAM
         // Show ASCII Data
@@ -1068,13 +1066,13 @@ bool iecDisk::sendFile()
 
         if(bi == 8)
         {
-            uint32_t t = (i * 100) / len;
-            Debug_printf(" %s (%d %d%%) [%d]\r\n", ba, i, t, avail);
+            uint32_t t = (count * 100) / len;
+            Debug_printf(" %s (%d %d%%) [%d]\r\n", ba, count, t, avail);
             bi = 0;
         }
 #else
-        uint32_t t = (i * 100) / len;
-        Debug_printf("\rTransferring %d%% [%d, %d]      ", t, i, avail);
+        uint32_t t = (count * 100) / len;
+        Debug_printf("\rTransferring %d%% [%d, %d]      ", t, count, avail);
 #endif
 
         // Exit if ATN is PULLED while sending
@@ -1095,7 +1093,18 @@ bool iecDisk::sendFile()
         // 	fnLedManager.toggle(eLed::LED_BUS);
         // }
     }
-    Debug_printf("\r\n=================================\r\n%d bytes sent of %d [SYS%d]\r\n", i, avail, sys_address);
+
+#ifdef DATA_STREAM
+    if (bi)
+    {
+      uint32_t t = (count * 100) / len;
+      ba[bi] = 0;
+      Debug_printf(" %s (%d %d%%) [%d]\r\n", ba, count, t, avail);
+      bi = 0;
+    }
+#endif
+
+    Debug_printf("\r\n=================================\r\n%d bytes sent of %d [SYS%d]\r\n", count, avail, sys_address);
 
     //Debug_printv("len[%d] avail[%d] success_rx[%d]", len, avail, success_rx);
 


### PR DESCRIPTION
There are 3 fixes:

* Send all bytes of a file, including the last one
* ATN being asserted immediately after the EOI byte isn't an error, still return the final byte
* ATN being asserted right after acking the EOI byte should not release DATA since interrupt already asserted it