### PR TITLE
rc2014: modem: refactor to use command frames

### DIFF
--- a/lib/bus/rc2014bus/rc2014bus.cpp
+++ b/lib/bus/rc2014bus/rc2014bus.cpp
@@ -35,64 +35,10 @@ uint8_t rc2014_checksum(uint8_t *buf, unsigned short len)
     return checksum;
 }
 
-rc2014Buffer::rc2014Buffer(unsigned size) :
-        size_(size),
-        dirty_(true)
-{
-    buffer_.reserve(size + 1);
-    buffer_.push_back(0); // set the first checksum
-}
-
-bool rc2014Buffer::validate()
-{
-    if (buffer_.size() == 0)
-        return true;
-
-    if (buffer_.size() == 1) {
-        if (buffer_.back() == 0) {
-            return true;
-        }
-        return false;
-    } 
-
-    uint8_t ck = rc2014_checksum(buffer_.data(), buffer_.size() - 1);
-
-    return ck == buffer_.back();
-}
-
-uint8_t* rc2014Buffer::data()
-{
-    return buffer_.data();
-}
-
-size_t rc2014Buffer::max_size()
-{
-    return size_;
-}
-
-size_t rc2014Buffer::data_size()
-{
-    return buffer_.size();
-}
-
-void rc2014Buffer::append(uint8_t val)
-{
-    buffer_.back() = val;
-    buffer_.push_back(rc2014_checksum(buffer_.data(), buffer_.size() - 1));
-}
-
 void virtualDevice::rc2014_send(uint8_t b)
 {
     rc2014Bus.busTxByte(b);
 }
-
-void virtualDevice::rc2014_send(rc2014Buffer& buffer)
-{
-    for (int i = 0; i < buffer.data_size(); i++) {
-        rc2014Bus.busTxByte(buffer.data()[i]);
-    }
-}
-
 
 void virtualDevice::rc2014_send_string(const std::string& str)
 {
@@ -239,7 +185,8 @@ void virtualDevice::rc2014_response_status()
 
 void virtualDevice::rc2014_handle_stream()
 {
-    //fnUartBUS.flush_input();
+    // flush fifo
+    streamFifoRx.clear();
 }
 
 bool virtualDevice::rc2014_poll_interrupt()

--- a/lib/bus/rc2014bus/rc2014bus.h
+++ b/lib/bus/rc2014bus/rc2014bus.h
@@ -7,8 +7,10 @@
 
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>
-#include <vector>
+#include <deque>
+#include <mutex>
 #include <string>
+#include <vector>
 
 #include <map>
 
@@ -55,20 +57,95 @@ union cmdFrame_t
 
 // buffer with inbuilt checksum
 // -- instantiate with desired buffer size + 1 for checksum
-class rc2014Buffer {
+template <size_t BUFFER_SIZE>
+class rc2014Fifo {
 public:
-    explicit rc2014Buffer(size_t size);
+    rc2014Fifo() { clear(); };
 
-    bool validate();
-    uint8_t* data();
-    size_t max_size();
-    size_t data_size();
-    void append(uint8_t val);
 
-protected:
-    std::vector<uint8_t> buffer_;
-    size_t size_;
-    bool dirty_;
+    bool is_empty() {
+        std::scoped_lock<std::mutex> lock(_m);
+        return (_i_head == _i_tail);
+    };
+
+    bool is_full() {
+        std::scoped_lock<std::mutex> lock(_m);
+        return ((_i_head + 1) % BUFFER_SIZE) == _i_tail;
+    };
+
+    bool is_overrun() {
+        std::scoped_lock<std::mutex> lock(_m);
+        return _overrun;
+    };
+
+    bool is_underrun() {
+        std::scoped_lock<std::mutex> lock(_m);
+        return _underrun;
+    };
+
+    void push(uint8_t val) {
+        if (is_full()) {
+            _overrun = true;
+            return;
+        }
+
+        std::scoped_lock<std::mutex> lock(_m);
+        _fifo[_i_head] = val;
+        _i_head = (_i_head + 1) % BUFFER_SIZE;
+    };
+
+    void push(uint8_t* buffer, size_t len) {
+        for (size_t i = 0; i < len; i++)
+            push(buffer[i]);
+    }
+
+    void push(const char* str) {
+        push(std::string(str));
+    }
+
+    void push(const std::string& str) {
+        for (auto &ch : str)
+            push(ch);
+    }
+
+    uint8_t pop() {
+        if (is_empty()) {
+            _overrun = true;
+            return 0xff;
+        }
+
+        std::scoped_lock<std::mutex> lock(_m);
+        uint8_t val = _fifo[_i_tail];
+        _i_tail = (_i_tail + 1) % BUFFER_SIZE;
+        return val;
+    };
+
+    void pop(uint8_t* buffer, size_t len) {
+        for (size_t i = 0; i < len; i++)
+            buffer[i] = pop();
+    }
+
+    void clear() {
+        std::scoped_lock<std::mutex> lock(_m);
+        _i_tail = _i_head = 0;
+        _overrun = _underrun = false;
+    };
+
+    size_t avail() {
+        std::scoped_lock<std::mutex> lock(_m);
+        if (_i_head == _i_tail)
+            return 0; // Empty buffer
+
+        return (_i_head - _i_tail + BUFFER_SIZE) % BUFFER_SIZE;
+    }
+
+private:
+    std::mutex _m;
+    std::array<uint8_t, BUFFER_SIZE> _fifo;
+    unsigned _i_tail;
+    unsigned _i_head;
+    bool _overrun;
+    bool _underrun;
 };
 
 class systemBus;
@@ -99,7 +176,6 @@ protected:
      * @return none
      */
     void rc2014_send(uint8_t b);
-    void rc2014_send(rc2014Buffer& buffer);
 
     /**
      * @brief Send string buffer to rc2014
@@ -277,6 +353,10 @@ public:
      * @return the device # (0-15) of this device
      */
     uint8_t id() { return _devnum; }
+
+protected:
+    rc2014Fifo<1024> streamFifoTx; // streamed data from rc2014
+    rc2014Fifo<1024> streamFifoRx; // streamed data destined for rc2014
 };
 
 /**

--- a/lib/device/rc2014/modem.cpp
+++ b/lib/device/rc2014/modem.cpp
@@ -531,7 +531,7 @@ void rc2014Modem::at_handle_answer()
         CRX = true;
 
         cmdMode = false;
-	fnUartBUS.flush();
+        streamFifoRx.clear();
         answerHack = false;
     }
 }

--- a/lib/device/rc2014/modem.cpp
+++ b/lib/device/rc2014/modem.cpp
@@ -1,5 +1,7 @@
 #ifdef BUILD_RC2014
 
+#include <string>
+
 #include "bus.h"
 #include "modem.h"
 
@@ -12,6 +14,7 @@
 #include "fnWiFi.h"
 
 #include "utils.h"
+
 
 #define RECVBUFSIZE 1024
 
@@ -40,8 +43,7 @@ void rc2014Modem::telnet_event_handler(telnet_t *telnet, telnet_event_t *ev)
     switch (ev->type)
     {
     case TELNET_EV_DATA:
-        if (ev->data.size && rc2014_send_buffer((uint8_t *)ev->data.buffer, ev->data.size) != ev->data.size)
-            Debug_printf("_telnet_event_handler(%d) - Could not write complete buffer to SIO.\n", ev->type);
+        streamFifoRx.push((uint8_t *)ev->data.buffer, ev->data.size);
         break;
     case TELNET_EV_SEND:
         get_tcp_client().write((uint8_t *)ev->data.buffer, ev->data.size);
@@ -103,6 +105,71 @@ rc2014Modem::~rc2014Modem()
     }
 }
 
+/**
+ * rc2014 Write command
+ * Write # of bytes specified by aux1/aux2 from tx_buffer out to rc2014. If protocol is unable to return requested
+ * number of bytes, return ERROR.
+ */
+void rc2014Modem::write()
+{
+    Debug_printf("rc2014Modem::write()\n");
+
+    memset(response, 0, sizeof(response));
+    rc2014_send_ack();
+
+    uint16_t num_bytes = (cmdFrame.aux2 << 8) + cmdFrame.aux1;
+
+    rc2014_recv_buffer(response, num_bytes);
+    rc2014_send_ack();
+
+    streamFifoTx.push(response, num_bytes);
+
+    rc2014_send_complete();
+}
+
+void rc2014Modem::read()
+{
+    Debug_printf("rc2014Modem::read()\n");
+
+    uint16_t num_bytes = (cmdFrame.aux2 << 8) + cmdFrame.aux1;
+    Debug_printf("rc2014Modem::read %u bytes\n", num_bytes);
+
+    rc2014_send_ack();
+
+    streamFifoRx.pop(response, num_bytes);
+
+    rc2014_send_buffer((uint8_t *)response, num_bytes);
+    rc2014_flush();
+
+    Debug_printf("rc2014Modem::read sent %u bytes\n", num_bytes);
+
+    rc2014_send_complete();
+}
+
+void rc2014Modem::status()
+{
+    Debug_printf("rc2014Modem::status()\n");
+    uint8_t response_len = 4;
+    size_t bytesWaiting = streamFifoRx.avail();
+
+    rc2014_send_ack();
+
+    uint16_t bytes_waiting = (bytesWaiting > RC2014_TX_BUFFER_SIZE) ?
+        RC2014_TX_BUFFER_SIZE : bytesWaiting;
+
+    response[0] = bytes_waiting & 0xFF;
+    response[1] = bytes_waiting >> 8;
+    response[2] = 0; // s.connected;
+    response[3] = 0; //s.error;
+    //receiveMode = STATUS;
+
+    rc2014_send_buffer(response, response_len);
+    rc2014_flush();
+
+    rc2014_send_complete();
+
+}
+
 void rc2014Modem::rc2014_control_status()
 {
 
@@ -135,8 +202,8 @@ void rc2014Modem::at_connect_resultCode(int modemBaud)
         resultCode = 1;
         break;
     }
-    rc2014_send_int(resultCode);
-    fnUartBUS.write(ASCII_CR);
+    streamFifoRx.push(resultCode);
+    streamFifoRx.push(ASCII_CR);
 }
 
 /**
@@ -145,9 +212,9 @@ void rc2014Modem::at_connect_resultCode(int modemBaud)
  */
 void rc2014Modem::at_cmd_resultCode(int resultCode)
 {
-    rc2014_send_int(resultCode);
-    rc2014_send(ASCII_CR);
-    rc2014_send(ASCII_LF);
+    streamFifoRx.push(std::to_string(resultCode));
+    streamFifoRx.push(ASCII_CR);
+    streamFifoRx.push(ASCII_LF);
 }
 
 /**
@@ -155,54 +222,50 @@ void rc2014Modem::at_cmd_resultCode(int resultCode)
 */
 void rc2014Modem::at_cmd_println()
 {
-    if (cmdOutput == false)
+    if (!cmdOutput)
         return;
 
-    rc2014_send(ASCII_CR);
-    rc2014_send(ASCII_LF);
-    rc2014_flush();
+    streamFifoRx.push(ASCII_CR);
+    streamFifoRx.push(ASCII_LF);
 }
 
 void rc2014Modem::at_cmd_println(const char *s, bool addEol)
 {
-    if (cmdOutput == false)
+    if (!cmdOutput)
         return;
 
-    rc2014_send_string(s);
+    streamFifoRx.push(std::string(s));
     if (addEol)
     {
-        rc2014_send(ASCII_CR);
-        rc2014_send(ASCII_LF);
+        streamFifoRx.push(ASCII_CR);
+        streamFifoRx.push(ASCII_LF);
     }
-    rc2014_flush();
 }
 
 void rc2014Modem::at_cmd_println(int i, bool addEol)
 {
-    if (cmdOutput == false)
+    if (!cmdOutput)
         return;
 
-    rc2014_send_int(i);
+    streamFifoRx.push(std::to_string(i));
     if (addEol)
     {
-        rc2014_send(ASCII_CR);
-        rc2014_send(ASCII_LF);
+        streamFifoRx.push(ASCII_CR);
+        streamFifoRx.push(ASCII_LF);
     }
-    rc2014_flush();
 }
 
 void rc2014Modem::at_cmd_println(std::string s, bool addEol)
 {
-    if (cmdOutput == false)
+    if (!cmdOutput)
         return;
 
-    rc2014_send_string(s);
+    streamFifoRx.push(s);
     if (addEol)
     {
-        rc2014_send(ASCII_CR);
-        rc2014_send(ASCII_LF);
+        streamFifoRx.push(ASCII_CR);
+        streamFifoRx.push(ASCII_LF);
     }
-    rc2014_flush();
 }
 
 void rc2014Modem::at_handle_wificonnect()
@@ -238,7 +301,7 @@ void rc2014Modem::at_handle_wificonnect()
     }
     if (retries >= 20)
     {
-        if (numericResultCode == true)
+        if (numericResultCode)
         {
             at_cmd_resultCode(RESULT_CODE_ERROR);
         }
@@ -249,7 +312,7 @@ void rc2014Modem::at_handle_wificonnect()
     }
     else
     {
-        if (numericResultCode == true)
+        if (numericResultCode)
         {
             at_cmd_resultCode(RESULT_CODE_OK);
         }
@@ -266,7 +329,7 @@ void rc2014Modem::at_handle_port()
     int port = std::stoi(cmd.substr(6));
     if (port > 65535 || port < 0)
     {
-        if (numericResultCode == true)
+        if (numericResultCode)
             at_cmd_resultCode(RESULT_CODE_ERROR);
         else
             at_cmd_println("ERROR");
@@ -282,7 +345,7 @@ void rc2014Modem::at_handle_port()
         listenPort = port;
         tcpServer.setMaxClients(1);
         tcpServer.begin(listenPort);
-        if (numericResultCode == true)
+        if (numericResultCode)
             at_cmd_resultCode(RESULT_CODE_OK);
         else
             at_cmd_println("OK");
@@ -321,7 +384,7 @@ void rc2014Modem::at_handle_get()
     // Establish connection
     if (!tcpClient.connect(host.c_str(), port))
     {
-        if (numericResultCode == true)
+        if (numericResultCode)
             at_cmd_resultCode(RESULT_CODE_NO_CARRIER);
         else
             at_cmd_println("NO CARRIER");
@@ -331,7 +394,7 @@ void rc2014Modem::at_handle_get()
     }
     else
     {
-        if (numericResultCode == true)
+        if (numericResultCode)
         {
             at_connect_resultCode(modemBaud);
             CRX = true;
@@ -468,7 +531,7 @@ void rc2014Modem::at_handle_answer()
         CRX = true;
 
         cmdMode = false;
-        fnUartBUS.flush();
+	fnUartBUS.flush();
         answerHack = false;
     }
 }
@@ -975,9 +1038,9 @@ void rc2014Modem::modemCommand()
 void rc2014Modem::rc2014_handle_stream()
 {
     /**** AT command mode ****/
-    if (cmdMode == true)
+    if (cmdMode)
     {
-        if (answerHack == true)
+        if (answerHack)
         {
             Debug_printf("XXX ANSWERHACK !!! SENDING ATA! ");
             cmd = "ATA";
@@ -989,7 +1052,7 @@ void rc2014Modem::rc2014_handle_stream()
         // In command mode but new unanswered incoming connection on server listen socket
         if ((listenPort > 0) && (tcpServer.hasClient()))
         {
-            if (autoAnswer == true)
+            if (autoAnswer)
             {
                 at_handle_answer();
             }
@@ -998,7 +1061,7 @@ void rc2014Modem::rc2014_handle_stream()
                 // Print RING every now and then while the new incoming connection exists
                 if ((fnSystem.millis() - lastRingMs) > RING_INTERVAL)
                 {
-                    if (numericResultCode == true)
+                    if (numericResultCode)
                         at_cmd_resultCode(RESULT_CODE_RING);
                     else
                         at_cmd_println("RING");
@@ -1009,11 +1072,11 @@ void rc2014Modem::rc2014_handle_stream()
 
         // In command mode - don't exchange with TCP but gather characters to a string
         //if (SIO_UART.available() /*|| blockWritePending == true */ )
-        if (fnUartBUS.available() > 0)
+        if (streamFifoTx.avail() > 0)
         {
             // get char from Atari SIO
             //char chr = SIO_UART.read();
-            char chr = fnUartBUS.read();
+            uint8_t chr = streamFifoTx.pop();
 
             // Return, enter, new line, carriage return.. anything goes to end the command
             if ((chr == ASCII_LF) || (chr == ASCII_CR))
@@ -1030,11 +1093,11 @@ void rc2014Modem::rc2014_handle_stream()
                     cmd.erase(len - 1);
                     // We don't assume that backspace is destructive
                     // Clear with a space
-                    if (commandEcho == true)
+                    if (commandEcho)
                     {
-                        rc2014_send(ASCII_BACKSPACE);
-                        rc2014_send(' ');
-                        rc2014_send(ASCII_BACKSPACE);
+                        streamFifoRx.push(ASCII_BACKSPACE);
+                        streamFifoRx.push(' ');
+                        streamFifoRx.push(ASCII_BACKSPACE);
                     }
                 }
             }
@@ -1042,8 +1105,8 @@ void rc2014Modem::rc2014_handle_stream()
             else if (chr == ATASCII_CLEAR_SCREEN ||
                      ((chr >= ATASCII_CURSOR_UP) && (chr <= ATASCII_CURSOR_RIGHT)))
             {
-                if (commandEcho == true)
-                    rc2014_send(chr);
+                if (commandEcho)
+                    streamFifoRx.push(chr);
             }
             else
             {
@@ -1052,8 +1115,8 @@ void rc2014Modem::rc2014_handle_stream()
                     //cmd.concat(chr);
                     cmd += chr;
                 }
-                if (commandEcho == true)
-                    rc2014_send(chr);
+                if (commandEcho)
+                    streamFifoRx.push(chr);
             }
         }
     }
@@ -1085,7 +1148,7 @@ void rc2014Modem::rc2014_handle_stream()
         }
 
         //int sioBytesAvail = SIO_UART.available();
-        int sioBytesAvail = rc2014_recv_available();
+        int sioBytesAvail = streamFifoTx.avail();
 
         // send from Atari to Fujinet
         if (sioBytesAvail && tcpClient.connected())
@@ -1100,8 +1163,8 @@ void rc2014Modem::rc2014_handle_stream()
 
             // Read from serial, the amount available up to
             // maximum size of the buffer
-            int sioBytesRead = rc2014_recv_buffer(&txBuf[0], //SIO_UART.readBytes(&txBuf[0],
-                                                   (sioBytesAvail > TX_BUF_SIZE) ? TX_BUF_SIZE : sioBytesAvail);
+            int sioBytesRead = (sioBytesAvail > TX_BUF_SIZE) ? TX_BUF_SIZE : sioBytesAvail;
+            streamFifoTx.pop(&txBuf[0], sioBytesRead);
 
             // Disconnect if going to AT mode with "+++" sequence
             for (int i = 0; i < (int)sioBytesRead; i++)
@@ -1150,8 +1213,7 @@ void rc2014Modem::rc2014_handle_stream()
             }
             else
             {
-                rc2014_send_buffer(buf, bytesRead);
-                rc2014_flush();
+                streamFifoRx.push(buf, bytesRead);
             }
 
             // And dump to sniffer, if enabled.
@@ -1213,6 +1275,17 @@ void rc2014Modem::rc2014_handle_stream()
             // tcpServer.begin(listenPort);
         }
     }
+
+}
+
+bool rc2014Modem::rc2014_poll_interrupt()
+{
+    rc2014_handle_stream();
+
+    if (streamFifoRx.avail() > 0)
+        return true;
+
+    return false;
 }
 
 void rc2014Modem::shutdown()
@@ -1230,7 +1303,20 @@ void rc2014Modem::rc2014_process(uint32_t commanddata, uint8_t checksum)
     cmdFrame.commanddata = commanddata;
     cmdFrame.checksum = checksum;
 
-    fnUartDebug.printf("rc2014_process() not implemented yet for this device. Cmd received: %02x\n", cmdFrame.comnd);
+    switch (cmdFrame.comnd)
+    {
+    case 'R':
+        read();
+        break;
+    case 'W':
+        write();
+        break;
+    case 'S':
+        status();
+        break;
+    default:
+        Debug_printf("rc2014 modem: unimplemented command: 0x%02x", cmdFrame.comnd);
+    }
 }
 
 #endif /* NEW_TARGET */

--- a/lib/device/rc2014/modem.h
+++ b/lib/device/rc2014/modem.h
@@ -4,7 +4,9 @@
 #include <time.h>
 
 #include <cstdint>
+#include <queue>
 #include <string>
+#include <vector>
 
 #include "bus.h"
 
@@ -182,7 +184,7 @@ private:
     long answerTimer;
     bool answered=false;
 
-    void rc2014_control_status() override;                 
+    void rc2014_control_status() override;
     void rc2014_process(uint32_t commanddata, uint8_t checksum) override;
     
     void crx_toggle(bool toggle);                // CRX active/inactive?
@@ -209,6 +211,8 @@ private:
     void at_handle_pb();
     void at_handle_pbclear();
 
+    uint8_t response[1024];
+
 protected:
     void shutdown() override;
 
@@ -218,6 +222,27 @@ public:
 
     rc2014Modem(FileSystem *_fs, bool snifferEnable);
     virtual ~rc2014Modem();
+
+    /**
+     * rc2014 Write command
+     * Write # of bytes specified by aux1/aux2 from tx_buffer out to rc2014. If protocol is unable to return requested
+     * number of bytes, return ERROR.
+     */
+    virtual void write();
+
+    /**
+     * rc2014 Read command
+     * Read # of bytes specified by aux1/aux2 from tx_buffer out to rc2014.
+     */
+    virtual void read();
+
+    /**
+     * rc2014 Status Command. First try to populate NetworkStatus object from protocol. If protocol not instantiated,
+     * or Protocol does not want to fill status buffer (e.g. due to unknown aux1/aux2 values), then try to deal
+     * with them locally. Then serialize resulting NetworkStatus object to rc2014.
+     */
+    virtual void status();
+
 
     time_t get_last_activity_time() { return _lasttime; } // timestamp of last input or output.
     ModemSniffer *get_modem_sniffer() { return modemSniffer; }
@@ -229,6 +254,7 @@ public:
 
     void telnet_event_handler(telnet_t *telnet, telnet_event_t *ev);
 
+    bool rc2014_poll_interrupt();
 };
 
 #endif /* rc2014_MODEM_H */

--- a/lib/device/rc2014/network.h
+++ b/lib/device/rc2014/network.h
@@ -75,6 +75,10 @@ public:
      */
     virtual void write();
 
+    /**
+     * rc2014 Read command
+     * Read # of bytes specified by aux1/aux2 from tx_buffer out to rc2014.
+     */
     virtual void read();
 
     /**


### PR DESCRIPTION
Since we moved to using an SPI bus for RC2014, the modem support had
become unusable. Refactor the the modem to use command frames,
adding a circular buffer to emulate a UART. Code on the RC2014 will
batch characters together to send/receive command frames in the
"driver"