### PR TITLE
Fixed cppcheck errors.

### DIFF
--- a/lib/device/cx16_i2c/fuji.cpp
+++ b/lib/device/cx16_i2c/fuji.cpp
@@ -329,6 +329,7 @@ void cx16Fuji::copy_file()
     if (ck != cx16_checksum(csBuf, sizeof(csBuf)))
     {
         cx16_error();
+        free(dataBuf);
         return;
     }
 
@@ -340,18 +341,21 @@ void cx16Fuji::copy_file()
     if (copySpec.empty() || copySpec.find_first_of("|") == string::npos)
     {
         cx16_error();
+        free(dataBuf);
         return;
     }
 
     if (cmdFrame.aux1 < 1 || cmdFrame.aux1 > 8)
     {
         cx16_error();
+        free(dataBuf);
         return;
     }
 
     if (cmdFrame.aux2 < 1 || cmdFrame.aux2 > 8)
     {
         cx16_error();
+        free(dataBuf);
         return;
     }
 
@@ -382,6 +386,7 @@ void cx16Fuji::copy_file()
     if (sourceFile == nullptr)
     {
         cx16_error();
+        free(dataBuf);
         return;
     }
 
@@ -390,6 +395,8 @@ void cx16Fuji::copy_file()
     if (destFile == nullptr)
     {
         cx16_error();
+        free(dataBuf);
+        fclose(sourceFile);
         return;
     }
 

--- a/lib/device/iec/network.h
+++ b/lib/device/iec/network.h
@@ -99,8 +99,9 @@ class iecNetwork : public virtualDevice
     {
         PROTOCOL,
         JSON
-    } channelMode[15] =
+    } channelMode[NUM_CHANNELS] =
         {
+            PROTOCOL,
             PROTOCOL,
             PROTOCOL,
             PROTOCOL,

--- a/lib/device/iwm/fuji.cpp
+++ b/lib/device/iwm/fuji.cpp
@@ -309,7 +309,7 @@ bool iwmFuji::mount_all()
 {
     bool nodisks = true; // Check at the end if no disks are in a slot and disable config
 
-    for (int i = 0; i < 8; i++)
+    for (int i = 0; i < MAX_DISK_DEVICES; i++)
     {
         fujiDisk &disk = _fnDisks[i];
         fujiHost &host = _fnHosts[disk.host_slot];

--- a/lib/device/rs232/fuji.cpp
+++ b/lib/device/rs232/fuji.cpp
@@ -338,6 +338,7 @@ void rs232Fuji::rs232_copy_file()
     if (ck != rs232_checksum(csBuf, sizeof(csBuf)))
     {
         rs232_error();
+        free(dataBuf);
         return;
     }
 
@@ -349,18 +350,21 @@ void rs232Fuji::rs232_copy_file()
     if (copySpec.empty() || copySpec.find_first_of("|") == string::npos)
     {
         rs232_error();
+        free(dataBuf);
         return;
     }
 
     if (cmdFrame.aux1 < 1 || cmdFrame.aux1 > 8)
     {
         rs232_error();
+        free(dataBuf);
         return;
     }
 
     if (cmdFrame.aux2 < 1 || cmdFrame.aux2 > 8)
     {
         rs232_error();
+        free(dataBuf);
         return;
     }
 
@@ -391,6 +395,7 @@ void rs232Fuji::rs232_copy_file()
     if (sourceFile == nullptr)
     {
         rs232_error();
+        free(dataBuf);
         return;
     }
 
@@ -399,6 +404,8 @@ void rs232Fuji::rs232_copy_file()
     if (destFile == nullptr)
     {
         rs232_error();
+        fclose(sourceFile);
+        free(dataBuf);
         return;
     }
 

--- a/lib/device/rs232/network.cpp
+++ b/lib/device/rs232/network.cpp
@@ -282,6 +282,8 @@ void rs232Network::rs232_write()
     if (newData == nullptr)
     {
         Debug_printf("Could not allocate %u bytes.\n", num_bytes);
+        rs232_error();
+        return;
     }
 
     rs232_ack();
@@ -291,6 +293,7 @@ void rs232Network::rs232_write()
     {
         status.error = NETWORK_ERROR_NOT_CONNECTED;
         rs232_error();
+        free(newData);
         return;
     }
 

--- a/lib/device/sio/fuji.cpp
+++ b/lib/device/sio/fuji.cpp
@@ -428,6 +428,7 @@ void sioFuji::sio_copy_file()
     if (ck != sio_checksum(csBuf, sizeof(csBuf)))
     {
         sio_error();
+        free(dataBuf);
         return;
     }
 
@@ -439,18 +440,21 @@ void sioFuji::sio_copy_file()
     if (copySpec.empty() || copySpec.find_first_of("|") == string::npos)
     {
         sio_error();
+        free(dataBuf);
         return;
     }
 
     if (cmdFrame.aux1 < 1 || cmdFrame.aux1 > 8)
     {
         sio_error();
+        free(dataBuf);
         return;
     }
 
     if (cmdFrame.aux2 < 1 || cmdFrame.aux2 > 8)
     {
         sio_error();
+        free(dataBuf);
         return;
     }
 
@@ -481,6 +485,7 @@ void sioFuji::sio_copy_file()
     if (sourceFile == nullptr)
     {
         sio_error();
+        free(dataBuf);
         return;
     }
 
@@ -489,6 +494,8 @@ void sioFuji::sio_copy_file()
     if (destFile == nullptr)
     {
         sio_error();
+        fclose(sourceFile);
+        free(dataBuf);
         return;
     }
 

--- a/lib/device/sio/network.cpp
+++ b/lib/device/sio/network.cpp
@@ -293,15 +293,16 @@ bool sioNetwork::sio_read_channel(unsigned short num_bytes)
 void sioNetwork::sio_write()
 {
     unsigned short num_bytes = sio_get_aux();
-    uint8_t *newData;
     bool err = false;
 
-    newData = (uint8_t *)malloc(num_bytes);
+    uint8_t *newData = (uint8_t *)malloc(num_bytes);
     Debug_printf("sioNetwork::sio_write( %d bytes)\n", num_bytes);
 
     if (newData == nullptr)
     {
         Debug_printf("Could not allocate %u bytes.\n", num_bytes);
+        sio_error();
+        return;
     }
 
     sio_ack();
@@ -316,6 +317,7 @@ void sioNetwork::sio_write()
         }
         status.error = NETWORK_ERROR_NOT_CONNECTED;
         sio_error();
+        free(newData);
         return;
     }
 
@@ -333,7 +335,9 @@ void sioNetwork::sio_write()
         sio_complete();
     }
     else
+    {
         sio_error();
+    }
 }
 
 /**

--- a/lib/network-protocol/FS.cpp
+++ b/lib/network-protocol/FS.cpp
@@ -61,7 +61,6 @@ bool NetworkProtocolFS::open_file()
 
 bool NetworkProtocolFS::open_dir()
 {
-    char *entryBuffer = (char *)malloc(256);
     openMode = DIR;
     dirBuffer.clear();
     update_dir_filename(opened_url);
@@ -80,6 +79,8 @@ bool NetworkProtocolFS::open_dir()
         fserror_to_error();
         return true;
     }
+
+    char *entryBuffer = (char *)malloc(256);
 
     while (read_dir_entry(entryBuffer, 255) == false)
     {

--- a/lib/network-protocol/Telnet.cpp
+++ b/lib/network-protocol/Telnet.cpp
@@ -114,6 +114,7 @@ bool NetworkProtocolTELNET::read(unsigned short len)
         if (!client.connected())
         {
             error = NETWORK_ERROR_NOT_CONNECTED;
+            free(newData);
             return true; // error
         }
 
@@ -126,6 +127,7 @@ bool NetworkProtocolTELNET::read(unsigned short len)
         if (errno == ECONNRESET)
         {
             error = NETWORK_ERROR_CONNECTION_RESET;
+            free(newData);
             return true;
         }
 

--- a/lib/network-protocol/UDP.cpp
+++ b/lib/network-protocol/UDP.cpp
@@ -94,6 +94,7 @@ bool NetworkProtocolUDP::read(unsigned short len)
         if (udp.available() == 0)
         {
             errno_to_error();
+            free(newData);
             return true;
         }
 
@@ -110,6 +111,7 @@ bool NetworkProtocolUDP::read(unsigned short len)
     // Return success
     Debug_printf("errno = %u\r\n", errno);
     error = 1;
+    free(newData);
     return NetworkProtocol::read(len);
 }
 


### PR DESCRIPTION
cppcheck: (error) Array 'channelMode[15]' accessed at index 15, which is out of bounds. [arrayIndexOutOfBounds] cppcheck: (error) Array '_fnDisks[6]' accessed at index 7, which is out of bounds. [arrayIndexOutOfBounds] cppcheck: (error) Memory leak: newData [memleak]
cppcheck: (error) Memory leak: dataBuf [memleak]
several fopen() with no fclose() fixed