### PR TITLE
more cppcheck warnings fixed

### DIFF
--- a/lib/bus/sio/sio.cpp
+++ b/lib/bus/sio/sio.cpp
@@ -543,7 +543,7 @@ int systemBus::getHighSpeedBaud()
 void systemBus::setUDPHost(const char *hostname, int port)
 {
     // Turn off if hostname is STOP
-    if (!strcmp(hostname, "STOP"))
+    if (hostname != nullptr && !strcmp(hostname, "STOP"))
     {
         if (_udpDev->udpstreamActive)
             _udpDev->sio_disable_udpstream();

--- a/lib/device/adamnet/network.cpp
+++ b/lib/device/adamnet/network.cpp
@@ -57,12 +57,9 @@ adamNetwork::~adamNetwork()
     transmitBuffer->clear();
     specialBuffer->clear();
 
-    if (receiveBuffer != nullptr)
-        delete receiveBuffer;
-    if (transmitBuffer != nullptr)
-        delete transmitBuffer;
-    if (specialBuffer != nullptr)
-        delete specialBuffer;
+    delete receiveBuffer;
+    delete transmitBuffer;
+    delete specialBuffer;
 }
 
 /** ADAM COMMANDS ***************************************************************/

--- a/lib/device/comlynx/fuji.cpp
+++ b/lib/device/comlynx/fuji.cpp
@@ -401,7 +401,7 @@ void lynxFuji::mount_all()
 {
     bool nodisks = true; // Check at the end if no disks are in a slot and disable config
 
-    for (int i = 0; i < 8; i++)
+    for (int i = 0; i < MAX_DISK_DEVICES; i++)
     {
         fujiDisk &disk = _fnDisks[i];
         fujiHost &host = _fnHosts[disk.host_slot];

--- a/lib/device/comlynx/fuji.h
+++ b/lib/device/comlynx/fuji.h
@@ -61,9 +61,9 @@ private:
     bool setSSIDStarted = false;
 
     uint8_t response[1024];
-    uint16_t response_len;
+    uint16_t response_len = 0;
 
-    systemBus *_comlynx_bus;
+    systemBus *_comlynx_bus = nullptr;
 
     fujiHost _fnHosts[MAX_HOSTS];
 
@@ -71,7 +71,7 @@ private:
 
     int _current_open_directory_slot = -1;
 
-    lynxDisk *_bootDisk; // special disk drive just for configuration
+    lynxDisk *_bootDisk = nullptr; // special disk drive just for configuration
 
     uint8_t bootMode = 0; // Boot mode 0 = CONFIG, 1 = MINI-BOOT
 

--- a/lib/device/comlynx/network.cpp
+++ b/lib/device/comlynx/network.cpp
@@ -57,12 +57,9 @@ lynxNetwork::~lynxNetwork()
     transmitBuffer->clear();
     specialBuffer->clear();
 
-    if (receiveBuffer != nullptr)
-        delete receiveBuffer;
-    if (transmitBuffer != nullptr)
-        delete transmitBuffer;
-    if (specialBuffer != nullptr)
-        delete specialBuffer;
+    delete receiveBuffer;
+    delete transmitBuffer;
+    delete specialBuffer;
 }
 
 /** LYNX COMMANDS ***************************************************************/

--- a/lib/device/comlynx/udpstream.h
+++ b/lib/device/comlynx/udpstream.h
@@ -18,7 +18,7 @@ class lynxUDPStream : public virtualDevice
 {
 private:
     fnUDP udpStream;
-    systemBus *_comlynx_bus;
+    systemBus *_comlynx_bus = nullptr;
 
     uint8_t buf_net[UDPSTREAM_BUFFER_SIZE];
     uint8_t buf_stream[UDPSTREAM_BUFFER_SIZE];

--- a/lib/device/cx16_i2c/disk.h
+++ b/lib/device/cx16_i2c/disk.h
@@ -18,7 +18,7 @@ private:
 
 public:
     cx16Disk();
-    fujiHost *host;
+    fujiHost *host = nullptr;
     mediatype_t mount(FILE *f, const char *filename, uint32_t disksize, mediatype_t disk_type = MEDIATYPE_UNKNOWN);
     void unmount();
     bool write_blank(FILE *f, uint16_t sectorSize, uint16_t numSectors);

--- a/lib/device/cx16_i2c/modem.cpp
+++ b/lib/device/cx16_i2c/modem.cpp
@@ -3,17 +3,14 @@
 #include "modem.h"
 
 cx16Modem::cx16Modem(FileSystem *_fs, bool snifferEnable)
+    : activeFS(_fs)
+    , modemSniffer(new ModemSniffer(activeFS, snifferEnable))
 {
-    activeFS = _fs;
-    modemSniffer = new ModemSniffer(activeFS, snifferEnable);
 }
 
 cx16Modem::~cx16Modem()
 {
-    if (modemSniffer != nullptr)
-    {
-        delete modemSniffer;
-    }
+    delete modemSniffer;
 }
 
 #endif /* BUILD_CX16 */

--- a/lib/device/cx16_i2c/modem.h
+++ b/lib/device/cx16_i2c/modem.h
@@ -12,7 +12,7 @@ class cx16Modem : public virtualDevice
 private:
     ModemSniffer* modemSniffer;
     FileSystem *activeFS;
-    time_t _lasttime;
+    time_t _lasttime = 0;
     
 public:
     cx16Modem(FileSystem *_fs, bool snifferEnable);

--- a/lib/device/drivewire/cassette.h
+++ b/lib/device/drivewire/cassette.h
@@ -129,8 +129,8 @@ private:
 
     void Clear_atari_sector_buffer(uint16_t len);
 
-    unsigned short block;
-    unsigned short baud;
+    unsigned short block = 0;
+    unsigned short baud = 0;
 
     size_t send_tape_block(size_t offset);
     void check_for_file();

--- a/lib/device/drivewire/disk.h
+++ b/lib/device/drivewire/disk.h
@@ -16,7 +16,7 @@ public:
     drivewireDisk();
     ~drivewireDisk();
 
-    fujiHost *host;
+    fujiHost *host = nullptr;
 
     mediatype_t disktype() { return _disk == nullptr ? MEDIATYPE_UNKNOWN : _disk->_mediatype; };
     mediatype_t mount(FILE *f, const char *filename, uint32_t disksize, mediatype_t disk_type = MEDIATYPE_UNKNOWN);

--- a/lib/device/drivewire/fuji.h
+++ b/lib/device/drivewire/fuji.h
@@ -56,7 +56,7 @@ struct appkey
 class drivewireFuji : public virtualDevice
 {
 private:
-    systemBus *_drivewire_bus;
+    systemBus *_drivewire_bus = nullptr;
 
     fujiHost _fnHosts[MAX_HOSTS];
 

--- a/lib/device/drivewire/network.cpp
+++ b/lib/device/drivewire/network.cpp
@@ -51,12 +51,9 @@ drivewireNetwork::~drivewireNetwork()
     transmitBuffer->clear();
     specialBuffer->clear();
 
-    if (receiveBuffer != nullptr)
-        delete receiveBuffer;
-    if (transmitBuffer != nullptr)
-        delete transmitBuffer;
-    if (specialBuffer != nullptr)
-        delete specialBuffer;
+    delete receiveBuffer;
+    delete transmitBuffer;
+    delete specialBuffer;
 }
 
 /** DRIVEWIRE COMMANDS ***************************************************************/

--- a/lib/device/h89/network.cpp
+++ b/lib/device/h89/network.cpp
@@ -51,12 +51,9 @@ H89Network::~H89Network()
     transmitBuffer->clear();
     specialBuffer->clear();
 
-    if (receiveBuffer != nullptr)
-        delete receiveBuffer;
-    if (transmitBuffer != nullptr)
-        delete transmitBuffer;
-    if (specialBuffer != nullptr)
-        delete specialBuffer;
+    delete receiveBuffer;
+    delete transmitBuffer;
+    delete specialBuffer;
 }
 
 /** H89 COMMANDS ***************************************************************/

--- a/lib/device/iwm/network.cpp
+++ b/lib/device/iwm/network.cpp
@@ -54,12 +54,9 @@ iwmNetwork::~iwmNetwork()
     transmitBuffer->clear();
     specialBuffer->clear();
 
-    if (receiveBuffer != nullptr)
-        delete receiveBuffer;
-    if (transmitBuffer != nullptr)
-        delete transmitBuffer;
-    if (specialBuffer != nullptr)
-        delete specialBuffer;
+    delete receiveBuffer;
+    delete transmitBuffer;
+    delete specialBuffer;
 }
 
 /** iwm COMMANDS ***************************************************************/

--- a/lib/device/new/network.cpp
+++ b/lib/device/new/network.cpp
@@ -55,12 +55,9 @@ adamNetwork::~adamNetwork()
     transmitBuffer->clear();
     specialBuffer->clear();
 
-    if (receiveBuffer != nullptr)
-        delete receiveBuffer;
-    if (transmitBuffer != nullptr)
-        delete transmitBuffer;
-    if (specialBuffer != nullptr)
-        delete specialBuffer;
+    delete receiveBuffer;
+    delete transmitBuffer;
+    delete specialBuffer;
 }
 
 /** ADAM COMMANDS ***************************************************************/

--- a/lib/device/rc2014/network.cpp
+++ b/lib/device/rc2014/network.cpp
@@ -55,12 +55,9 @@ rc2014Network::~rc2014Network()
     transmitBuffer->clear();
     specialBuffer->clear();
 
-    if (receiveBuffer != nullptr)
-        delete receiveBuffer;
-    if (transmitBuffer != nullptr)
-        delete transmitBuffer;
-    if (specialBuffer != nullptr)
-        delete specialBuffer;
+    delete receiveBuffer;
+    delete transmitBuffer;
+    delete specialBuffer;
 }
 
 /** rc2014 COMMANDS ***************************************************************/

--- a/lib/device/rs232/network.cpp
+++ b/lib/device/rs232/network.cpp
@@ -67,12 +67,9 @@ rs232Network::~rs232Network()
     transmitBuffer->clear();
     specialBuffer->clear();
 
-    if (receiveBuffer != nullptr)
-        delete receiveBuffer;
-    if (transmitBuffer != nullptr)
-        delete transmitBuffer;
-    if (specialBuffer != nullptr)
-        delete specialBuffer;
+    delete receiveBuffer;
+    delete transmitBuffer;
+    delete specialBuffer;
 }
 
 /** RS232 COMMANDS ***************************************************************/

--- a/lib/device/s100spi/network.cpp
+++ b/lib/device/s100spi/network.cpp
@@ -55,12 +55,9 @@ s100spiNetwork::~s100spiNetwork()
     transmitBuffer->clear();
     specialBuffer->clear();
 
-    if (receiveBuffer != nullptr)
-        delete receiveBuffer;
-    if (transmitBuffer != nullptr)
-        delete transmitBuffer;
-    if (specialBuffer != nullptr)
-        delete specialBuffer;
+    delete receiveBuffer;
+    delete transmitBuffer;
+    delete specialBuffer;
 }
 
 /** s100spi COMMANDS ***************************************************************/

--- a/lib/device/sio/network.cpp
+++ b/lib/device/sio/network.cpp
@@ -65,12 +65,9 @@ sioNetwork::~sioNetwork()
     transmitBuffer->clear();
     specialBuffer->clear();
 
-    if (receiveBuffer != nullptr)
-        delete receiveBuffer;
-    if (transmitBuffer != nullptr)
-        delete transmitBuffer;
-    if (specialBuffer != nullptr)
-        delete specialBuffer;
+    delete receiveBuffer;
+    delete transmitBuffer;
+    delete specialBuffer;
 }
 
 /** SIO COMMANDS ***************************************************************/

--- a/lib/meatloaf/device/flash.cpp
+++ b/lib/meatloaf/device/flash.cpp
@@ -433,9 +433,10 @@ void FlashHandle::obtain(std::string m_path, std::string mode) {
         // it will be caught by the real file open later on
 
         char *pathStr = new char[m_path.length()];
-        strncpy(pathStr, m_path.data(), m_path.length());
 
         if (pathStr) {
+            strncpy(pathStr, m_path.data(), m_path.length());
+            
             // Make dirs up to the final fnamepart
             char *ptr = strchr(pathStr, '/');
             while (ptr) {

--- a/lib/meatloaf/disk/d64.cpp
+++ b/lib/meatloaf/disk/d64.cpp
@@ -424,15 +424,15 @@ time_t D64File::getLastWrite() {
 }
 
 time_t D64File::getCreationTime() {
-    tm *entry_time = 0;
+    tm entry_time;
     auto entry = ImageBroker::obtain<D64IStream>(streamFile->url)->entry;
-    entry_time->tm_year = entry.year + 1900;
-    entry_time->tm_mon = entry.month;
-    entry_time->tm_mday = entry.day;
-    entry_time->tm_hour = entry.hour;
-    entry_time->tm_min = entry.minute;
+    entry_time.tm_year = entry.year + 1900;
+    entry_time.tm_mon = entry.month;
+    entry_time.tm_mday = entry.day;
+    entry_time.tm_hour = entry.hour;
+    entry_time.tm_min = entry.minute;
 
-    return mktime(entry_time);
+    return mktime(&entry_time);
 }
 
 bool D64File::exists() {

--- a/lib/modem-sniffer/modem-sniffer.cpp
+++ b/lib/modem-sniffer/modem-sniffer.cpp
@@ -9,10 +9,10 @@
 
 ModemSniffer::ModemSniffer(FileSystem *_fs, bool _enable)
 {
-    Debug_printf("ModemSniffer::ModemSniffer(%s)\n", _fs->typestring());
-
     if (_fs == nullptr)
         Debug_printf("_fs is NULL!\n");
+    else
+        Debug_printf("ModemSniffer::ModemSniffer(%s)\n", _fs->typestring());
 
     activeFS = _fs;
     direction = INIT;

--- a/lib/network-protocol/HTTP.cpp
+++ b/lib/network-protocol/HTTP.cpp
@@ -460,8 +460,6 @@ bool NetworkProtocolHTTP::write_file_handle_get_header(uint8_t *buf, unsigned sh
     {
         char *requestedHeader = (char *)malloc(len);
 
-        memset(requestedHeader, 0, len);
-
         if (requestedHeader == nullptr)
         {
             Debug_printf("Could not allocate %u bytes for header\r\n", len);

--- a/lib/network-protocol/UDP.cpp
+++ b/lib/network-protocol/UDP.cpp
@@ -104,8 +104,6 @@ bool NetworkProtocolUDP::read(unsigned short len)
         // Add new data to buffer.
         newString = string((char *)newData, len);
         *receiveBuffer += newString;
-
-        free(newData);
     }
 
     // Return success

--- a/lib/utils/utils.cpp
+++ b/lib/utils/utils.cpp
@@ -482,7 +482,7 @@ bool util_concat_paths(char *dest, const char *parent, const char *child, int de
         }
 
         // Skip a slash in the child if it starts with one so we don't have two slashes
-        if (child[0] == '/' && child[0] == '\\')
+        if (child[0] == '/' || child[0] == '\\')
             child++;
 
         int clen = strlcpy(dest + plen, child, dest_size - plen);


### PR DESCRIPTION
UDP.cpp(error) Memory pointed to by 'newData' is freed twice. [doubleFree]
calling operator delete with a null ptr is ok, the function does nothing initializing class member variables