### PR TITLE
Add -z option to build.sh to build firmware zip

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,8 @@ UPLOAD_IMAGE=0
 UPLOAD_FS=0
 EXCLUDE_GRAPH=0
 DEV_MODE=0
+ZIP_MODE=0
+AUTOCLEAN=1
 
 function show_help {
   echo "Usage: $(basename $0) [-b|-e ENV|-c|-m|-x|-t TARGET|-h]"
@@ -27,11 +29,13 @@ function show_help {
   echo "   -c       # run clean before build"
   echo "   -d       # add dev flag to build"
   echo "   -m       # run monitor after build"
+  echo "   -n       # do not autoclean"
   echo "   -u       # upload image (device code)"
   echo "   -f       # upload filesystem (webUI etc)"
   echo "   -x       # exclude dep graph output from logging"
   echo "   -e ENV   # use specific environment"
   echo "   -t TGT   # run target task (default of none means do build, but -b must be specified"
+  echo "   -z       # build flashable zip"
   echo "   -h       # this help"
   exit 1
 }
@@ -40,7 +44,7 @@ if [ $# -eq 0 ] ; then
   show_help
 fi
 
-while getopts ":bcde:fmt:uxh" flag
+while getopts ":bcde:fmnt:uxzh" flag
 do
   case "$flag" in
     b) RUN_BUILD=1 ;;
@@ -49,14 +53,28 @@ do
     e) ENV_NAME=${OPTARG} ;;
     f) UPLOAD_FS=1 ;;
     m) SHOW_MONITOR=1 ;;
+    n) AUTOCLEAN=0 ;;
     t) TARGET_NAME=${OPTARG} ;;
     u) UPLOAD_IMAGE=1 ;;
     x) EXCLUDE_GRAPH=1 ;;
+    z) ZIP_MODE=1 ;;
     h) show_help ;;
     *) show_help ;;
   esac
 done
 shift $((OPTIND - 1))
+
+# remove any AUTOADD option left from previous run
+sed -i '/# AUTOADD/d' platformio.ini
+
+if [ ${ZIP_MODE} -eq 1 ] ; then
+  # find line with post:build_firmwarezip.py and add before it the option uncommented
+  sed -i '/^;[ ]*post:build_firmwarezip.py/i \    \post:build_firmwarezip.py # AUTOADD' platformio.ini
+  pio run -t clean -t buildfs
+  pio run --disable-auto-clean
+  sed -i '/# AUTOADD/d' platformio.ini
+  exit 0
+fi
 
 ENV_ARG=""
 if [ -n "${ENV_NAME}" ] ; then
@@ -77,11 +95,16 @@ if [ ${DO_CLEAN} -eq 1 ] ; then
   pio run -t clean ${ENV_ARG}
 fi
 
+AUTOCLEAN_ARG=""
+if [ ${AUTOCLEAN} -eq 0 ] ; then
+  AUTOCLEAN_ARG="--disable-auto-clean"
+fi
+
 if [ ${RUN_BUILD} -eq 1 ] ; then
   if [ ${EXCLUDE_GRAPH} -eq 1 ] ; then
-    pio run ${DEV_MODE_ARG} $ENV_ARG $TARGET_ARG 2>&1 | egrep -av '^\|   \|'
+    pio run ${DEV_MODE_ARG} $ENV_ARG $TARGET_ARG $AUTOCLEAN_ARG 2>&1 | egrep -av '^\|   \|'
   else
-    pio run ${DEV_MODE_ARG} $ENV_ARG $TARGET_ARG 2>&1
+    pio run ${DEV_MODE_ARG} $ENV_ARG $TARGET_ARG $AUTOCLEAN_ARG 2>&1
   fi
 fi
 


### PR DESCRIPTION
For @mozzwald 

run:
```shell
$ ./build.sh -z
```

it will clean, build filesystem, then build with the zip options enabled.
cleans up after itself.

It works by finding the line containing "; post:build_firmwarezip.py" and then inserts the post option ABOVE it.
After building zip, it removes the option it added, leaving the platformio.ini file as it was.

It will fail if there's no line with the comment at the end of the extra_scripts section, so the current template should work.
