### PR TITLE
Fix sed calls to work on Mac

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -64,17 +64,22 @@ do
 done
 shift $((OPTIND - 1))
 
-# remove any AUTOADD option left from previous run
-sed -i '/# AUTOADD/d' platformio.ini
+# remove any AUTOADD option left from previous run, and delete the generated backup file
+sed -i.bu '/# AUTOADD/d' platformio.ini
+rm 2>/dev/null platformio.ini.bu
 
 if [ ${ZIP_MODE} -eq 1 ] ; then
   # find line with post:build_firmwarezip.py and add before it the option uncommented
-  sed -i '/^;[ ]*post:build_firmwarezip.py/i \    \post:build_firmwarezip.py # AUTOADD' platformio.ini
+  sed -i.bu '/^;[ ]*post:build_firmwarezip.py/i\
+    post:build_firmwarezip.py # AUTOADD
+' platformio.ini
   pio run -t clean -t buildfs
   pio run --disable-auto-clean
-  sed -i '/# AUTOADD/d' platformio.ini
+  sed -i.bu '/# AUTOADD/d' platformio.ini
+  rm 2>/dev/null platformio.ini.bu
   exit 0
 fi
+
 
 ENV_ARG=""
 if [ -n "${ENV_NAME}" ] ; then

--- a/platformio-sample.ini
+++ b/platformio-sample.ini
@@ -95,6 +95,7 @@ extra_scripts =
     pre:build_version.py
     pre:build_webui.py
 ;    post:build_firmwarezip.py ; Optional, build firmware ZIP file for flash tool
+; DO NOT REMOVE THE ABOVE COMMENT - it is used by build.sh using -z option
 lib_ldf_mode = deep+
 upload_speed = 460800 ;921600
 ;upload_port = COM1 ; Windows


### PR DESCRIPTION
For @dillera - `build.sh -z` now supported on mac.

This is a small change to use sed in a way that's compatible with Macs version.