### PR TITLE
RC2014: fuji: align SSID size with other platforms

### DIFF
--- a/lib/device/rc2014/fuji.cpp
+++ b/lib/device/rc2014/fuji.cpp
@@ -127,7 +127,7 @@ void rc2014Fuji::rc2014_net_scan_result()
     // Response to FUJICMD_GET_SCAN_RESULT
     struct
     {
-        char ssid[MAX_SSID_LEN];
+        char ssid[MAX_SSID_LEN+1];
         uint8_t rssi;
     } detail;
 
@@ -159,7 +159,7 @@ void rc2014Fuji::rc2014_net_get_ssid()
     // Response to FUJICMD_GET_SSID
     struct
     {
-        char ssid[MAX_SSID_LEN];
+        char ssid[MAX_SSID_LEN+1];
         char password[MAX_WIFI_PASS_LEN];
     } cfg;
 
@@ -201,7 +201,7 @@ void rc2014Fuji::rc2014_net_set_ssid()
         // Data for FUJICMD_SET_SSID
         struct
         {
-            char ssid[MAX_SSID_LEN];
+            char ssid[MAX_SSID_LEN+1];
             char password[MAX_WIFI_PASS_LEN];
         } cfg;
 

--- a/lib/device/rc2014/fuji.h
+++ b/lib/device/rc2014/fuji.h
@@ -24,7 +24,7 @@
 
 typedef struct
 {
-    char ssid[32];
+    char ssid[MAX_SSID_LEN+1];
     char hostname[64];
     unsigned char localIP[4];
     unsigned char gateway[4];
@@ -33,7 +33,7 @@ typedef struct
     unsigned char macAddress[6];
     unsigned char bssid[6];
     char fn_version[15];
-} AdapterConfig;
+} __attribute__((packed)) AdapterConfig;
 
 enum appkey_mode : uint8_t
 {


### PR DESCRIPTION
The RC2014 does not match the other platforms with the size of the SSID array. Fix this.