### PR TITLE
RC2014: network: remove need for N: specifier

### DIFF
--- a/lib/device/rc2014/network.cpp
+++ b/lib/device/rc2014/network.cpp
@@ -653,7 +653,7 @@ void rc2014Network::create_devicespec(string d)
 */
 void rc2014Network::create_url_parser()
 {
-    std::string url = deviceSpec.substr(deviceSpec.find(":") + 1);
+    std::string url = deviceSpec;
     urlParser = EdUrlParser::parseUrl(url);
 }
 


### PR DESCRIPTION
Remove the need for the N: specifier for opening
the network device.

This is part of the rc2014 library refactoring for the network device.