### PR TITLE
RC2014: network: fix json query

### DIFF
--- a/lib/device/rc2014/network.cpp
+++ b/lib/device/rc2014/network.cpp
@@ -368,9 +368,8 @@ void rc2014Network::rc2014_set_json_query()
             in[i] = 0x00;
     }
 
-    inp = strrchr((const char *)in, ':');
+    inp = (const char *)in;
     Debug_printf("#1 %s\n",inp);
-    inp++;
     json.setReadQuery(string(inp),cmdFrame.aux2);
     json_bytes_remaining = json.readValueLen();
     tmp = (uint8_t *)malloc(json.readValueLen());


### PR DESCRIPTION
Since we removed the N: prefix from network device specs for RC2014, we missed one usage in rc2014_set_json_query()!

Fix this.