### PR TITLE
Apple II - high score enabled

### DIFF
--- a/lib/device/iwm/disk.cpp
+++ b/lib/device/iwm/disk.cpp
@@ -525,7 +525,15 @@ mediatype_t iwmDisk::mount(FILE *f, const char *filename, uint32_t disksize, med
     case MEDIATYPE_PO:
         Debug_printf("\r\nMedia Type PO");
         _disk = new MediaTypePO();
+        _disk->_media_host = host;
+        strcpy(_disk->_disk_filename, filename);
         mt = _disk->mount(f, disksize);
+
+        // firmware needs to believe a high score enabled disk is 
+        // not write-protected. Otherwise it will skip write process
+        if (_disk->high_score_enabled)
+          readonly = false;
+
         device_active = true; //change status only after we are mounted
         //_disk->fileptr() = f;
         // mt = MEDIATYPE_PO;

--- a/lib/device/iwm/disk.h
+++ b/lib/device/iwm/disk.h
@@ -44,6 +44,7 @@ protected:
 public:
     uint8_t blank_header_type = 0; // unadorned by default.
     iwmDisk();
+    fujiHost *host = nullptr;
     mediatype_t mount(FILE *f, const char *filename, uint32_t disksize, mediatype_t disk_type = MEDIATYPE_UNKNOWN);
     void unmount();
     bool write_blank(FILE *f, uint16_t sectorSize, uint16_t numSectors);

--- a/lib/device/iwm/fuji.cpp
+++ b/lib/device/iwm/fuji.cpp
@@ -217,6 +217,7 @@ void iwmFuji::iwm_ctrl_disk_image_mount() // SP CTRL command
     Debug_printf("\r\nSelecting '%s' from host #%u as %s on D%u:\n",
                  disk.filename, disk.host_slot, flag, deviceSlot + 1);
 
+    disk.disk_dev.host = &host;
     disk.fileh = host.file_open(disk.filename, disk.filename, sizeof(disk.filename), flag);
 
     // We've gotten this far, so make sure our bootable CONFIG disk is disabled

--- a/lib/media/apple/mediaType.h
+++ b/lib/media/apple/mediaType.h
@@ -2,6 +2,7 @@
 #define _MEDIA_TYPE_
 
 #include <stdio.h>
+#include <fujiHost.h>
 
 #define INVALID_SECTOR_VALUE 65536
 
@@ -26,11 +27,15 @@ class MediaType
 {
 protected:
     FILE *_media_fileh = nullptr;
+    FILE *oldFileh = nullptr; /* Temp fileh for high score enabled games */
+    FILE *hsFileh = nullptr; /* Temp fileh for high score enabled games */
+
     uint32_t _media_image_size = 0;
     uint32_t _media_num_sectors = 0;
     uint16_t _media_sector_size = DISK_BYTES_PER_SECTOR_SINGLE;
     int32_t _media_last_sector = INVALID_SECTOR_VALUE;
     uint8_t _media_controller_status = DISK_CTRL_STATUS_CLEAR;
+    uint16_t _high_score_block = 0; /* High score block to allow write. 1-65535 */
 
 public:
     // struct
@@ -51,6 +56,11 @@ public:
 
     uint32_t num_blocks;
     // FILE* fileptr() {return _media_fileh;}
+
+    char _disk_filename[256];
+    fujiHost *_media_host = nullptr;
+    FILE *_media_hsfileh = nullptr;
+    bool high_score_enabled = false;
 
     // uint8_t _media_sectorbuff[DISK_SECTORBUF_SIZE];
 

--- a/lib/media/apple/mediaTypePO.cpp
+++ b/lib/media/apple/mediaTypePO.cpp
@@ -2,6 +2,10 @@
 
 #include "mediaTypePO.h"
 
+#include <cstring>
+#include "utils.h"
+#include "../../include/debug.h"
+
 bool MediaTypePO::read(uint32_t blockNum, uint16_t *count, uint8_t* buffer)
 {
     size_t readsize = *count;
@@ -13,7 +17,12 @@ if (blockNum == 0 || blockNum != last_block_num + 1) // example optimization, on
         return true;
     }
   }
-  last_block_num = blockNum;
+
+  if (high_score_enabled && _high_score_block == blockNum)
+    last_block_num = INVALID_SECTOR_VALUE; // try to invalidate cache if game re-reads hs table
+  else
+    last_block_num = blockNum;
+
   readsize = fread((unsigned char *)buffer, 1, readsize, _media_fileh); // Reading block from SD Card
   return (readsize != *count);
 }
@@ -21,6 +30,15 @@ if (blockNum == 0 || blockNum != last_block_num + 1) // example optimization, on
 bool MediaTypePO::write(uint32_t blockNum, uint16_t *count, uint8_t* buffer)
 {
     size_t writesize = *count;
+
+    if (high_score_enabled && blockNum == _high_score_block)
+    {
+        Debug_printf("high score: Swapping file handles\r\n");
+        oldFileh = _media_fileh;
+        hsFileh = _media_host->file_open(_disk_filename, _disk_filename, strlen(_disk_filename) +1, "r+");
+        _media_fileh = hsFileh;
+    }
+
     if (blockNum != last_block_num + 1) // example optimization, only do seek if not writing next block -tschak
     {
          if (fseek(_media_fileh, (blockNum * writesize) + offset, SEEK_SET))
@@ -36,6 +54,17 @@ bool MediaTypePO::write(uint32_t blockNum, uint16_t *count, uint8_t* buffer)
        reset_seek_opto();
        return true;
     }
+
+    if (high_score_enabled && blockNum == _high_score_block)
+    {
+        Debug_printf("high score: Reverting file handles.\r\n");
+        if (hsFileh != nullptr)
+            fclose(hsFileh);
+
+        _media_fileh = oldFileh;
+        last_block_num = INVALID_SECTOR_VALUE; // Invalidate cache
+    }
+
     return false;
 }
 
@@ -47,10 +76,22 @@ bool MediaTypePO::format(uint16_t *respopnsesize)
 mediatype_t MediaTypePO::mount(FILE *f, uint32_t disksize)
 {
     diskiiemulation = false;
-    char hdr[4];
-    fread(&hdr,sizeof(char),4,f);
+    char hdr[64];
+    fread(&hdr,sizeof(char),64,f);
     if (hdr[0] == '2' && hdr[1] == 'I' && hdr[2] == 'M' && hdr[3] == 'G')
+    {
+        // check for 'high score enabled' signature
+        if (hdr[48] == 'H' && hdr[49] == 'I')
+        {
+            _high_score_block = UINT16_FROM_HILOBYTES(hdr[51], hdr[50]);
+            if (_high_score_block > 0)
+            {
+                Debug_printf("high score: Requested block: 0x%04x\r\n", _high_score_block);
+                high_score_enabled = true;
+            }
+        }
         offset = 64;
+    }
   _media_fileh = f;
   disksize -= offset;
   num_blocks = disksize/512;


### PR DESCRIPTION
Tested with 2 machines that having the same disk (CHAMP.LODERUN.HI.img) mounted read-only mode at the same time. 

For this program, it looks like the high score table is read at startup and re-read prior to posting a new score. So the high score table will not be updated during attract mode, but will show recently submitted scores from other machines prior to adding a new entry.

Trivia. Championship Lode Runner tests the disk for its write permission during boot up. If the game is deemed to be write-protected, only the attract mode is displayed. With the high score enabled hackery, the write test passes and the player can start level 1.