### PR TITLE
Add extended Adapter Config information

### DIFF
--- a/lib/device/sio/fuji.cpp
+++ b/lib/device/sio/fuji.cpp
@@ -1118,10 +1118,52 @@ void sioFuji::sio_close_directory()
     sio_complete();
 }
 
+void sioFuji::sio_get_adapter_config_extended()
+{
+    // return string versions of the data rather than just bytes
+    AdapterConfigExtended cfg;
+    memset(&cfg, 0, sizeof(cfg));       // ensures all strings are null terminated
+
+    strlcpy(cfg.fn_version, fnSystem.get_fujinet_version(true), sizeof(cfg.fn_version));
+
+    if (!fnWiFi.connected())
+    {
+        strlcpy(cfg.ssid, "NOT CONNECTED", sizeof(cfg.ssid));
+    }
+    else
+    {
+        strlcpy(cfg.hostname, fnSystem.Net.get_hostname().c_str(), sizeof(cfg.hostname));
+        strlcpy(cfg.ssid, fnWiFi.get_current_ssid().c_str(), sizeof(cfg.ssid));
+        fnWiFi.get_current_bssid(cfg.bssid);
+        fnSystem.Net.get_ip4_info(cfg.localIP, cfg.netmask, cfg.gateway);
+        fnSystem.Net.get_ip4_dns_info(cfg.dnsIP);
+    }
+
+    fnWiFi.get_mac(cfg.macAddress);
+
+    // convert fields to strings
+    strlcpy(cfg.sLocalIP, fnSystem.Net.get_ip4_address_str().c_str(), 16);
+    strlcpy(cfg.sGateway, fnSystem.Net.get_ip4_gateway_str().c_str(), 16);
+    strlcpy(cfg.sDnsIP,   fnSystem.Net.get_ip4_dns_str().c_str(),     16);
+    strlcpy(cfg.sNetmask, fnSystem.Net.get_ip4_mask_str().c_str(),    16);
+
+    sprintf(cfg.sMacAddress, "%02X:%02X:%02X:%02X:%02X:%02X", cfg.macAddress[0], cfg.macAddress[1], cfg.macAddress[2], cfg.macAddress[3], cfg.macAddress[4], cfg.macAddress[5]);
+    sprintf(cfg.sBssid,      "%02X:%02X:%02X:%02X:%02X:%02X", cfg.bssid[0], cfg.bssid[1], cfg.bssid[2], cfg.bssid[3], cfg.bssid[4], cfg.bssid[5]);
+
+    bus_to_computer((uint8_t *)&cfg, sizeof(cfg), false);
+
+}
+
 // Get network adapter configuration
 void sioFuji::sio_get_adapter_config()
 {
-    Debug_println("Fuji cmd: GET ADAPTER CONFIG");
+    Debug_printf("Fuji cmd: GET ADAPTER CONFIG (aux1:%hu)\r\n", cmdFrame.aux1);
+    if (cmdFrame.aux1 == 1)
+    {
+        Debug_println("Returning extended adapter config information");
+        sio_get_adapter_config_extended();
+        return;
+    }
 
     // Response to  FUJICMD_GET_ADAPTERCONFIG
     AdapterConfig cfg;

--- a/lib/device/sio/fuji.h
+++ b/lib/device/sio/fuji.h
@@ -42,6 +42,25 @@ typedef struct
     char fn_version[15];
 } AdapterConfig;
 
+typedef struct
+{
+    char ssid[33];
+    char hostname[64];
+    unsigned char localIP[4];
+    unsigned char gateway[4];
+    unsigned char netmask[4];
+    unsigned char dnsIP[4];
+    unsigned char macAddress[6];
+    unsigned char bssid[6];
+    char fn_version[15];
+    char sLocalIP[16];
+    char sGateway[16];
+    char sNetmask[16];
+    char sDnsIP[16];
+    char sMacAddress[18];
+    char sBssid[18];
+} AdapterConfigExtended;
+
 enum appkey_mode : uint8_t
 {
     APPKEYMODE_READ = 0,
@@ -112,6 +131,7 @@ protected:
     void sio_net_get_wifi_enabled();   // 0xEA
     void sio_disk_image_umount();      // 0xE9
     void sio_get_adapter_config();     // 0xE8
+    void sio_get_adapter_config_extended(); // 0xE8
     void sio_new_disk();               // 0xE7
     void sio_unmount_host();           // 0xE6
     void sio_get_directory_position(); // 0xE5

--- a/lib/utils/utils.cpp
+++ b/lib/utils/utils.cpp
@@ -864,3 +864,30 @@ void util_ascii_to_petscii_str(std::string &s)
                    [](unsigned char c)
                    { return util_ascii_to_petscii(c); });
 }
+
+char *util_hexdump(const void *buf, size_t len) {
+  const unsigned char *p = (const unsigned char *) buf;
+  size_t i, idx, n = 0, ofs = 0, dlen = len * 5 + 100;
+  char ascii[17] = "", *dst = (char *) calloc(1, dlen);
+  if (dst == NULL) return dst;
+  for (i = 0; i < len; i++) {
+    idx = i % 16;
+    if (idx == 0) {
+      if (i > 0 && dlen > n)
+        n += (size_t) snprintf(dst + n, dlen - n, "  %s\n", ascii);
+      if (dlen > n)
+        n += (size_t) snprintf(dst + n, dlen - n, "%04x ", (int) (i + ofs));
+    }
+    if (dlen < n) break;
+    n += (size_t) snprintf(dst + n, dlen - n, " %02x", p[i]);
+    ascii[idx] = (char) (p[i] < 0x20 || p[i] > 0x7e ? '.' : p[i]);
+    ascii[idx + 1] = '\0';
+  }
+  while (i++ % 16) {
+    if (n < dlen) n += (size_t) snprintf(dst + n, dlen - n, "%s", "   ");
+  }
+  if (n < dlen) n += (size_t) snprintf(dst + n, dlen - n, "  %s\n", ascii);
+  if (n > dlen - 1) n = dlen - 1;
+  dst[n] = '\0';
+  return dst;
+}

--- a/lib/utils/utils.h
+++ b/lib/utils/utils.h
@@ -89,4 +89,7 @@ char util_ascii_to_petscii(char c);
 void util_petscii_to_ascii_str(std::string &s);
 void util_ascii_to_petscii_str(std::string &s);
 
+// generic hex dump for debug output
+char *util_hexdump(const void *buf, size_t len);
+
 #endif // _FN_UTILS_H


### PR DESCRIPTION
This extends command $E8 (get adapter config) to return additional strings for the various IP and MAC values to save the client from having to do it.
