### PR TITLE
Add bad-connection detection to set-ssid

### DIFF
--- a/lib/config/fnc_wifi.cpp
+++ b/lib/config/fnc_wifi.cpp
@@ -57,8 +57,7 @@ void fnConfig::_read_section_wifi(std::stringstream &ss)
     Debug_println("Reading wifi section");
 
     // Throw out any existing data
-    _wifi.ssid.clear();
-    _wifi.passphrase.clear();
+    reset_wifi();
 
     std::string line;
     // Read lines until one starts with '[' which indicates a new section

--- a/lib/device/sio/fuji.cpp
+++ b/lib/device/sio/fuji.cpp
@@ -21,6 +21,8 @@
 
 #include "base64.h"
 
+#define ADDITIONAL_DETAILS_BYTES 10
+
 sioFuji theFuji; // global fuji device object
 
 // sioDisk sioDiskDevs[MAX_HOSTS];
@@ -219,82 +221,94 @@ void sioFuji::sio_net_set_ssid()
 
     uint8_t ck = bus_to_peripheral((uint8_t *)&cfg, sizeof(cfg));
 
-    if (sio_checksum((uint8_t *)&cfg, sizeof(cfg)) != ck)
+    if (sio_checksum((uint8_t *)&cfg, sizeof(cfg)) != ck) {
         sio_error();
-    else
+        return;
+    }
+
+    bool save = cmdFrame.aux1 != 0;
+
+    Debug_printf("Connecting to net: >%s< password: >%s<\r\n", cfg.ssid, cfg.password);
+
+    int test_result = fnWiFi.test_connect(cfg.ssid, cfg.password);
+    if (test_result != 0)
     {
-        bool save = cmdFrame.aux1 != 0;
+        Debug_println("Could not connect to target SSID. Aborting save.");
+        sio_error();
+        return;
+    }
 
-        Debug_printf("Connecting to net: %s password: %s\n", cfg.ssid, cfg.password);
+    // Only save these if we're asked to, otherwise assume it was a test for connectivity
+    if (save)
+    {
+        // 1. if this is a new SSID and not in the old stored, we should push the current one to the top of the stored configs, and everything else down.
+        // 2. If this was already in the stored configs, push the stored one to the top, remove the new one from stored so it becomes current only.
+        // 3. if this is same as current, then just save it again. User reconnected to current, nothing to change in stored. This is default if above don't happen
 
-        fnWiFi.connect(cfg.ssid, cfg.password);
-
-        // Only save these if we're asked to, otherwise assume it was a test for connectivity
-        if (save)
+        int ssid_in_stored = -1;
+        for (i = 0; i < MAX_WIFI_STORED; i++)
         {
-            // 1. if this is a new SSID and not in the old stored, we should push the current one to the top of the stored configs, and everything else down.
-            // 2. If this was already in the stored configs, push the stored one to the top, remove the new one from stored so it becomes current only.
-            // 3. if this is same as current, then just save it again. User reconnected to current, nothing to change in stored. This is default if above don't happen
-
-            int ssid_in_stored = -1;
-            for (i = 0; i < MAX_WIFI_STORED; i++)
+            if (Config.get_wifi_stored_ssid(i) == cfg.ssid)
             {
-                if (Config.get_wifi_stored_ssid(i) == cfg.ssid)
-                {
-                    ssid_in_stored = i;
-                    break;
-                }
+                ssid_in_stored = i;
+                break;
             }
-
-            // case 1
-            if (ssid_in_stored == -1 && Config.have_wifi_info() && Config.get_wifi_ssid() != cfg.ssid)
-            {
-                Debug_println("Case 1: Didn't find new ssid in stored, and it's new. Pushing everything down 1 and old current to 0");
-                // Move enabled stored down one, last one will drop off
-                for (int j = MAX_WIFI_STORED - 1; j > 0; j--)
-                {
-                    bool enabled = Config.get_wifi_stored_enabled(j - 1);
-                    if (!enabled)
-                        continue;
-
-                    Config.store_wifi_stored_ssid(j, Config.get_wifi_stored_ssid(j - 1));
-                    Config.store_wifi_stored_passphrase(j, Config.get_wifi_stored_passphrase(j - 1));
-                    Config.store_wifi_stored_enabled(j, true); // already confirmed this is enabled
-                }
-                // push the current to the top of stored
-                Config.store_wifi_stored_ssid(0, Config.get_wifi_ssid());
-                Config.store_wifi_stored_passphrase(0, Config.get_wifi_passphrase());
-                Config.store_wifi_stored_enabled(0, true);
-            }
-
-            // case 2
-            if (ssid_in_stored != -1 && Config.have_wifi_info() && Config.get_wifi_ssid() != cfg.ssid)
-            {
-                Debug_printf("Case 2: Found new ssid in stored at %d, and it's not current (should never happen). Pushing everything down 1 and old current to 0\n", ssid_in_stored);
-                // found the new SSID at ssid_in_stored, so move everything above it down one slot, and store the current at 0
-                for (int j = ssid_in_stored; j > 0; j--)
-                {
-                    Config.store_wifi_stored_ssid(j, Config.get_wifi_stored_ssid(j - 1));
-                    Config.store_wifi_stored_passphrase(j, Config.get_wifi_stored_passphrase(j - 1));
-                    Config.store_wifi_stored_enabled(j, true);
-                }
-
-                // push the current to the top of stored
-                Config.store_wifi_stored_ssid(0, Config.get_wifi_ssid());
-                Config.store_wifi_stored_passphrase(0, Config.get_wifi_passphrase());
-                Config.store_wifi_stored_enabled(0, true);
-            }
-
-            // save the new SSID as current
-            Config.store_wifi_ssid(cfg.ssid, sizeof(cfg.ssid));
-            // Clear text here, it will be encrypted internally if enabled for encryption
-            Config.store_wifi_passphrase(cfg.password, sizeof(cfg.password));
-
-            Config.save();
         }
 
-        sio_complete();
+        // case 1
+        if (ssid_in_stored == -1 && Config.have_wifi_info() && Config.get_wifi_ssid() != cfg.ssid)
+        {
+            Debug_println("Case 1: Didn't find new ssid in stored, and it's new. Pushing everything down 1 and old current to 0");
+            // Move enabled stored down one, last one will drop off
+            for (int j = MAX_WIFI_STORED - 1; j > 0; j--)
+            {
+                bool enabled = Config.get_wifi_stored_enabled(j - 1);
+                if (!enabled)
+                    continue;
+
+                Config.store_wifi_stored_ssid(j, Config.get_wifi_stored_ssid(j - 1));
+                Config.store_wifi_stored_passphrase(j, Config.get_wifi_stored_passphrase(j - 1));
+                Config.store_wifi_stored_enabled(j, true); // already confirmed this is enabled
+            }
+            // push the current to the top of stored
+            Config.store_wifi_stored_ssid(0, Config.get_wifi_ssid());
+            Config.store_wifi_stored_passphrase(0, Config.get_wifi_passphrase());
+            Config.store_wifi_stored_enabled(0, true);
+        }
+
+        // case 2
+        if (ssid_in_stored != -1 && Config.have_wifi_info() && Config.get_wifi_ssid() != cfg.ssid)
+        {
+            Debug_printf("Case 2: Found new ssid in stored at %d, and it's not current (should never happen). Pushing everything down 1 and old current to 0\n", ssid_in_stored);
+            // found the new SSID at ssid_in_stored, so move everything above it down one slot, and store the current at 0
+            for (int j = ssid_in_stored; j > 0; j--)
+            {
+                Config.store_wifi_stored_ssid(j, Config.get_wifi_stored_ssid(j - 1));
+                Config.store_wifi_stored_passphrase(j, Config.get_wifi_stored_passphrase(j - 1));
+                Config.store_wifi_stored_enabled(j, true);
+            }
+
+            // push the current to the top of stored
+            Config.store_wifi_stored_ssid(0, Config.get_wifi_ssid());
+            Config.store_wifi_stored_passphrase(0, Config.get_wifi_passphrase());
+            Config.store_wifi_stored_enabled(0, true);
+        }
+
+        // save the new SSID as current
+        Config.store_wifi_ssid(cfg.ssid, sizeof(cfg.ssid));
+        // Clear text here, it will be encrypted internally if enabled for encryption
+        Config.store_wifi_passphrase(cfg.password, sizeof(cfg.password));
+
+        Config.save();
     }
+    Debug_println("Restarting WiFiManager");
+    fnWiFi.start();
+
+    // give it a few seconds to restart the WiFi before we return to the client, who will immediately start checking status
+    // and get errors if we're not up yet
+    fnSystem.delay(3000);
+
+    sio_complete();
 }
 
 // Get WiFi Status
@@ -1003,8 +1017,192 @@ void _set_additional_direntry_details(fsdir_entry_t *f, uint8_t *dest, uint8_t m
     dest[9] = MediaType::discover_disktype(f->filename);
 }
 
+// TODO: VERIFY THIS CODE. THE STASH SEEMED CORRUPT
+void sioFuji::sio_read_directory_block()
+{
+    // aux1 holds entry size for each record
+    uint8_t maxlen = cmdFrame.aux1;
+
+    // aux2:
+    // b0-2 = number of pages - 1 (i.e. 1 to 8)
+    // b3,4 = not used
+    // b5   = extended entry information (as per normal, adds 10 bytes of information to each entry at start)
+    // b6,7 = block mode marker already checked.
+
+    bool is_extended = ((cmdFrame.aux2 & 0x20) == 0x20);
+    uint8_t pages = (cmdFrame.aux2 & 0x07) + 1;
+
+    Debug_printf("Fuji cmd: READ DIRECTORY BLOCK (pages=%d, maxlen=%d, extended: %d)\n", pages, maxlen, is_extended);
+    
+    std::vector<uint8_t> response;
+    std::vector<uint8_t> start_offsets; // holds all the offsets for each dir entry in the response
+    std::vector<uint8_t> data_block;    // the data for each dir entry. no terminator char needed as we track the offsets. Double 0x7f is end of dir, and no more entries will come
+
+    uint16_t response_max = pages * 256;
+
+    if (_current_open_directory_slot == -1)
+    {
+        Debug_print("No currently open directory\n");
+        sio_error();
+        return;
+    }
+
+    bool is_eod = false;
+    char current_entry[256];
+    uint16_t num_entries = 0;
+    uint16_t total_size = 9; // header bytes
+
+    uint16_t initial_pos = _fnHosts[_current_open_directory_slot].dir_tell();
+
+    // keep filling buffers up until it can't fit another maxlen (plus header bytes etc)
+    // or we hit end of dir
+    while ( !is_eod && num_entries < 256 )
+    {
+        uint16_t additional_size = 0;
+        uint16_t pos_before_next = _fnHosts[_current_open_directory_slot].dir_tell();
+        fsdir_entry_t *f = _fnHosts[_current_open_directory_slot].dir_nextfile();
+        if (f == nullptr)
+        {
+            // reached end of dir
+            is_eod = true;
+            current_entry[0] = 0x7F;
+            current_entry[1] = 0x7F;
+            current_entry[2] = 0;
+            additional_size = 2;
+        }
+        else
+        {
+            Debug_printf("::read_direntry \"%s\"\n", f->filename);
+
+            int bufsize;
+            char *filenamedest = current_entry;
+
+            // If 0x80 is set on AUX2, send back additional information
+            if (is_extended)
+            {
+                _set_additional_direntry_details(f, (uint8_t *)current_entry, maxlen);
+                // Adjust remaining size of buffer and file path destination
+                bufsize = sizeof(current_entry) - ADDITIONAL_DETAILS_BYTES;
+                filenamedest = current_entry + ADDITIONAL_DETAILS_BYTES;
+            }
+            else
+            {
+                bufsize = maxlen;
+            }
+
+            int filelen = util_ellipsize(f->filename, filenamedest, bufsize);
+            additional_size = filelen + is_extended ? ADDITIONAL_DETAILS_BYTES : 0;
+
+            // Add a slash at the end of directory entries
+            if (f->isDir && filelen < (bufsize - 2))
+            {
+                current_entry[filelen] = '/';
+                current_entry[filelen + 1] = '\0';
+                additional_size++;
+            }
+
+        }
+
+        // would this take us over the limit? 2 for start_offset bytes.
+        uint16_t new_size = total_size + 2 + additional_size;
+
+        if (new_size > response_max) {
+            Debug_printf("skipping add, would have taken us to %d size. additional was: %d\n", new_size, additional_size);
+            // reset to previous pos, and exit loop
+            _fnHosts[_current_open_directory_slot].dir_seek(pos_before_next);
+            break;
+        } else {
+            Debug_printf("adding additional entry with size: %d\n", additional_size);
+        }
+
+
+        start_offsets.push_back(static_cast<uint8_t>(data_block.size() & 0xFF)); // lo byte of current size (which is same as offset)
+        start_offsets.push_back(static_cast<uint8_t>((data_block.size() >> 8) & 0xFF)); // high byte
+
+        // add the string to the data block without the terminating null
+        if (is_extended)
+        {
+            // strlen doesn't work as we have prepended some additional information
+            // add the additional bytes first
+            for(int i=0; i < ADDITIONAL_DETAILS_BYTES; i++)
+            {
+                data_block.push_back(static_cast<uint8_t>(current_entry[i]));
+            }
+            // Then add the string part
+            int s_len = std::strlen(current_entry + ADDITIONAL_DETAILS_BYTES);
+            data_block.insert(data_block.end(), current_entry + ADDITIONAL_DETAILS_BYTES, current_entry + ADDITIONAL_DETAILS_BYTES + std::strlen(current_entry + ADDITIONAL_DETAILS_BYTES));
+        } else {
+            data_block.insert(data_block.end(), current_entry, current_entry + std::strlen(current_entry));
+        }
+
+        total_size = 9 + data_block.size() + start_offsets.size();
+        Debug_printf("current sizes, data: %d, offsets: %d, total: %d\n", data_block.size(), start_offsets.size(), data_block.size() + start_offsets.size());
+
+
+        num_entries++;
+    }
+
+    // ###################################################################
+    // CREATE THE RESPONSE BLOCK:
+    // ###################################################################
+    // byte 0-1 = "MF" (Multi-File, take your pick :D )
+    // byte 2   = Flags (currently 0x80 = Extended Information)
+    // byte 3   = Max Size Per Entry (maxlen from input)
+    // byte 4   = Num Entries in block (max 255)
+    // byte 5-6 = Total size of block (i.e. size without padding)
+    // byte 7-8 = First Position in block (i.e. dir pos value at start), allows up to 64k entries over all blocks
+    // Num Entries x 2 = Offsets in Data for each entry
+    // Data x Num Entries = data for each dir.
+    // 
+    // All above is < pages x 256 in size
+    
+    // HEADER BYTES
+    std::string headerBytes = "MF";
+    response.insert(response.end(), headerBytes.begin(), headerBytes.end());
+
+    // FLAGS
+    uint8_t header_flags = is_extended ? 0x80 : 0;  // more flags may come
+    response.push_back(header_flags);
+
+    // MAX SIZE PER ENTRY
+    response.push_back(maxlen);
+
+    // NUM ENTRIES
+    response.push_back(static_cast<uint8_t>(num_entries));
+
+    // Total size
+    int final_size = 9 + data_block.size() + start_offsets.size();
+    response.push_back(static_cast<uint8_t>(final_size & 0xFF));
+    response.push_back(static_cast<uint8_t>((final_size >> 8) & 0xFF));
+
+    // INITIAL POS VALUE
+    response.push_back(static_cast<uint8_t>(initial_pos & 0xFF));
+    response.push_back(static_cast<uint8_t>((initial_pos >> 8) & 0xFF));
+
+    // OFFSETS
+    response.insert(response.end(), start_offsets.begin(), start_offsets.end());
+
+    // DATA
+    response.insert(response.end(), data_block.begin(), data_block.end());
+
+    Debug_printf("Actual data size: %d to atari\n", response.size());
+    char *s = util_hexdump(response.data(), response.size());
+    Debug_printf("dump: \n%s\n", s);
+
+    // buffer with 0s to requested size
+    response.resize(response_max, 0);
+
+    bus_to_computer(response.data(), response_max, false);
+}
+
 void sioFuji::sio_read_directory_entry()
 {
+     if ((cmdFrame.aux2 & 0xC0) == 0xC0) {
+        // Block mode directory entry
+        sio_read_directory_block();
+        return;
+    }
+
     uint8_t maxlen = cmdFrame.aux1;
     Debug_printf("Fuji cmd: READ DIRECTORY ENTRY (max=%hu)\n", maxlen);
 
@@ -1033,7 +1231,6 @@ void sioFuji::sio_read_directory_entry()
         int bufsize = sizeof(current_entry);
         char *filenamedest = current_entry;
 
-#define ADDITIONAL_DETAILS_BYTES 10
         // If 0x80 is set on AUX2, send back additional information
         if (cmdFrame.aux2 & 0x80)
         {

--- a/lib/device/sio/fuji.h
+++ b/lib/device/sio/fuji.h
@@ -122,6 +122,7 @@ protected:
     void sio_disk_image_mount();       // 0xF8
     void sio_open_directory();         // 0xF7
     void sio_read_directory_entry();   // 0xF6
+    void sio_read_directory_block();   // 0xF6
     void sio_close_directory();        // 0xF5
     void sio_read_host_slots();        // 0xF4
     void sio_write_host_slots();       // 0xF3

--- a/lib/hardware/fnWiFi.h
+++ b/lib/hardware/fnWiFi.h
@@ -11,7 +11,10 @@
 
 #define FNWIFI_RECONNECT_RETRIES 4
 #define FNWIFI_SCAN_RESULTS_MAX 20
-#define FNWIFI_BIT_CONNECTED BIT0
+
+#define WIFI_CONNECTED_BIT    BIT0
+#define WIFI_FAIL_BIT         BIT1
+#define WIFI_NO_IP_YET_BIT    BIT2
 
 // using namespace std;
 
@@ -41,6 +44,9 @@ private:
 
     char *_mac_to_string(char dest[18], uint8_t mac[6]);
 
+    static void conn_event_handler(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data);
+    static esp_err_t block();
+
     static void _wifi_event_handler(void *arg, esp_event_base_t event_base,
                                     int32_t event_id, void *event_data);
     EventGroupHandle_t _wifi_event_group;
@@ -63,6 +69,8 @@ public:
     void stop();
 
     ~WiFiManager();
+
+    int test_connect(const char *ssid, const char *password);
 
     int connect(const char *ssid, const char *password);
     int connect();


### PR DESCRIPTION
This change will first try the given ssid/password combination before saving it to fnconfig.

It works by shutting down the existing wifimanager, starting a new mini version with some blocking code that checks whether a disconnect or connect event happens.
The disconnect tells us the config was bad, and we then stop the saving, and report the error to the host.

If the config was good, the wifi manager is restarted, with a small delay to allow it to connect, and the host is then given a success code, allowing them to then check the wifi status and see everything is good.

I've also (sorry) add the start of the block directory code to this commit as I will be adding it anyway. Nothing calls it, but I kept losing it in between stashing changes.

I've test compiling everything only on Atari board. 