### PR TITLE
Add 00 dstats $FB command to change json parameters

### DIFF
--- a/lib/device/sio/network.h
+++ b/lib/device/sio/network.h
@@ -392,6 +392,12 @@ private:
     void sio_set_json_query();
 
     /**
+     * @brief Set JSON parameters. (must be in JSON channelMode)
+     * Used to affect values on the JSON object
+     */
+    void sio_set_json_parameters();
+
+    /**
      * @brief Set timer rate for PROCEED timer in ms
      */
     void sio_set_timer_rate();

--- a/lib/fnjson/fnjson.cpp
+++ b/lib/fnjson/fnjson.cpp
@@ -54,6 +54,12 @@ void FNJSON::setProtocol(NetworkProtocol *newProtocol)
     _protocol = newProtocol;
 }
 
+void FNJSON::setQueryParam(uint8_t qp)
+{
+    Debug_printf("FNJSON::setQueryParam(0x%02hx)\r\n", qp);
+    _queryParam = qp;
+}
+
 /**
  * Set read query string
  */

--- a/lib/fnjson/fnjson.h
+++ b/lib/fnjson/fnjson.h
@@ -30,6 +30,7 @@ public:
     bool readValue(uint8_t *buf, unsigned short len);
     string processString(string in);
     int json_bytes_remaining = 0;
+    void setQueryParam(uint8_t qp);
     
 private:
     cJSON *_json = nullptr;


### PR DESCRIPTION
See https://github.com/FujiNetWIFI/fujinet-platformio/wiki/N:-SIO-Command-$FB---Set-JSON-Parameters

This allows host to change JSON parameters from the host using ioctl commands:

```cpp
#ifdef BUILD_ATARI
    err = network_ioctl(0xFB, 0, 1, ipify_json, 0, 0, 0);    // set json Query Param
    err = network_ioctl(0xFB, 1, 0x00, ipify_json, 0, 0, 0);    // set json Line Ending (default is usually 0x9b)
#endif
```