### PR TITLE
fix web mount list on apple2

### DIFF
--- a/lib/device/iwm/fuji.cpp
+++ b/lib/device/iwm/fuji.cpp
@@ -1105,7 +1105,7 @@ void iwmFuji::setup(iwmBus *iwmbus)
 
 int iwmFuji::get_disk_id(int drive_slot)
 {
-    return -1;
+    return 0;
 }
 std::string iwmFuji::get_host_prefix(int host_slot)
 {


### PR DESCRIPTION
Fix web interface mount list to not show (D�:) on every drive slot.

The return type of `get_disk_id` is `int`, but httpServiceParser (the only caller) casts it to `char`, and then checks if it is > 0. Unfortunately `char` is unsigned, so that didn’t work as intended.

Fixed by changing `get_disk_id` to return 0 instead of -1.