### PR TITLE
Remove dependency on os.h

### DIFF
--- a/lib/base64/base64.c
+++ b/lib/base64/base64.c
@@ -7,8 +7,8 @@
  */
 
 #include <stdint.h>
+#include <string.h>
 
-#include "os.h"
 #include "base64.h"
 
 static const char base64_table[65] =
@@ -33,7 +33,7 @@ static char * base64_gen_encode(const unsigned char *src, size_t len,
 	olen++; /* nul termination */
 	if (olen < len)
 		return NULL; /* integer overflow */
-	out = os_malloc(olen);
+	out = malloc(olen);
 	if (out == NULL)
 		return NULL;
 
@@ -88,7 +88,7 @@ static unsigned char * base64_gen_decode(const char *src, size_t len,
 	int pad = 0;
 	size_t extra_pad;
 
-	os_memset(dtable, 0x80, 256);
+	memset(dtable, 0x80, 256);
 	for (i = 0; i < sizeof(base64_table) - 1; i++)
 		dtable[(unsigned char) table[i]] = (unsigned char) i;
 	dtable['='] = 0;
@@ -104,7 +104,7 @@ static unsigned char * base64_gen_decode(const char *src, size_t len,
 	extra_pad = (4 - count % 4) % 4;
 
 	olen = (count + extra_pad) / 4 * 3;
-	pos = out = os_malloc(olen);
+	pos = out = malloc(olen);
 	if (out == NULL)
 		return NULL;
 
@@ -136,7 +136,7 @@ static unsigned char * base64_gen_decode(const char *src, size_t len,
 					pos -= 2;
 				else {
 					/* Invalid padding */
-					os_free(out);
+					free(out);
 					return NULL;
 				}
 				break;


### PR DESCRIPTION
The FN code using this code presumes anyhow that 'os_malloc' is the same as 'malloc'.