### PR TITLE
rc2014: disk: add command for number of sectors

### DIFF
--- a/lib/device/rc2014/disk.h
+++ b/lib/device/rc2014/disk.h
@@ -22,6 +22,7 @@ private:
     void write(bool verify);
     void format();
     void status();
+    void get_size();
 
     bool write_blank(FILE *f, uint16_t sectorSize, uint16_t numSectors);
 

--- a/lib/media/rc2014/mediaType.cpp
+++ b/lib/media/rc2014/mediaType.cpp
@@ -95,4 +95,8 @@ uint16_t MediaType::sector_size(uint16_t sector)
     return DISK_BYTES_PER_SECTOR_SINGLE;
 }
 
+uint32_t MediaType::num_sectors() {
+    return _media_num_sectors;
+}
+
 #endif // NEW_TARGET

--- a/lib/media/rc2014/mediaType.h
+++ b/lib/media/rc2014/mediaType.h
@@ -80,6 +80,7 @@ public:
 
     static mediatype_t discover_mediatype(const char *filename, uint32_t disksize);
     uint16_t sector_size(uint16_t sector);
+    uint32_t num_sectors();
 
     virtual ~MediaType();
 };


### PR DESCRIPTION
camelforth requires the size of disk, as it's quite agnostic. Add this command to the Disk device interface.