### PR TITLE
fix run-fujinet shebang

### DIFF
--- a/distfiles/run-fujinet
+++ b/distfiles/run-fujinet
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 fn_pid=0
 rc=75


### PR DESCRIPTION
`/bin/sh` doesn't support functions - need to use Bash instead.