### PR TITLE
create build dir instead of throwing an error about it not being there

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -129,10 +129,7 @@ fi
 # PC BUILD using cmake
 if [ ! -z "$PC_TARGET" ] ; then
   echo "PC Build Mode"
-  if [ ! -d "$SCRIPT_DIR/build" ] ; then
-    echo "ERROR: Could not find build dir to run cmake in"
-    exit 1
-  fi
+  mkdir -p "$SCRIPT_DIR/build"
   if [ $DO_CLEAN -eq 1 ] ; then
     echo "Removing old build artifacts"
     rm -rf $SCRIPT_DIR/build/*

--- a/distfiles/run-fujinet
+++ b/distfiles/run-fujinet
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 fn_pid=0
 rc=75


### PR DESCRIPTION
Instead of throwing an error when the `build/` directory doesn't exist when doing the FN-PC builds, just create the directory & continue on with the build.