### PR TITLE
keep empty build/ dir in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ sdkconfig.fujinet-v1
 include/version.h
 build/CMakeCache.txt
 build/*
+!build/.gitkeep
 out/*
 
 # ignore generated WebUI files


### PR DESCRIPTION
Keeps an empty `build/` directory in the repo so it is there when the repo is cloned.