### PR TITLE
Better detection of gsed on homebrew.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ if [ "$OS_TYPE" = "Linux" ]; then
     echo "Running on a Linux system. Wise choice."
 elif [ "$OS_TYPE" = "Darwin" ]; then
     echo "Running on a Macintosh system."
-    BINARY_PATH="/usr/local/opt/gnu-sed/libexec/gnubin/sed"
+    BINARY_PATH="$(which gsed)"
     if [ -f "$BINARY_PATH" ]; then
       echo "Proper sed Binary file found: $BINARY_PATH"
     else


### PR DESCRIPTION
On modern arm macs homebrew is installed under `/opt/homebrew`.
```
$ uname -sm
Darwin arm64
$ brew -v
Homebrew 4.2.8
$ which gsed
/opt/homebrew/bin/gsed
```
Also: 
> The --with-default-names option is removed since January 2019
https://stackoverflow.com/a/34815955

Looking for gsed in the path should be the most accurate use of gnu-sed when using homebrew on x86 or arm.